### PR TITLE
Use "docs-deploy-server.zeit.sh" alias for the deploy server

### DIFF
--- a/deploy-server/now.json
+++ b/deploy-server/now.json
@@ -1,5 +1,5 @@
 {
-  "alias": "zeit-docs-deploy-server.now.sh",
+  "alias": "docs-deploy-server.zeit.sh",
   "env": {
     "ZEIT_TOKEN": "@zeit-docs-zeit-token",
     "GH_KEY": "@geist-gh-key"

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -33,7 +33,7 @@ async function run() {
   }
 
   // Upload the app to the deploy server
-  const url = `https://zeit-docs-deploy-server.now.sh/deploy/${PULL_REQUEST_ID}`
+  const url = `https://docs-deploy-server.zeit.sh/deploy/${PULL_REQUEST_ID}`
   const upload = shell.exec(`curl -F "app=@app.tar.gz" ${url}`)
   if (upload.code !== 0) {
     throw new Error(upload.stderr)


### PR DESCRIPTION
It's nice to use `zeit.sh` for this internal app.