### PR TITLE
Increase line height on docs headings

### DIFF
--- a/lib/with-doc.js
+++ b/lib/with-doc.js
@@ -89,7 +89,7 @@ export default function withDoc(options) {
           .content h1 {
             color: #000;
             font-size: 26px;
-            line-height: 20px;
+            line-height: 1.1;
             font-weight: 400;
             margin: 0 0 30px 0;
             padding: 0;


### PR DESCRIPTION
When viewing a docs pages on a mobile device, if the title wraps to a new line, the line height is pretty cramped. This PR takes a stab at bumping it up. Definitely open to feedback here!

### Screenshots:

**Before:**
![image](https://user-images.githubusercontent.com/6248612/30094066-3195a2ae-928f-11e7-94aa-8a4d16c23573.png)

**After:**
![image](https://user-images.githubusercontent.com/6248612/30094074-3f893c40-928f-11e7-812d-79c0591a9906.png)

### Possible drawbacks:
- It's possible this was intentional (in which case please feel free to close this PR 😄).
- There may be a `font-size`/`line-height` ratio that's preferred to keep consistency across the app.
- I went with a unitless `line-height` value, but a fixed pixel value may be preferred.
