### PR TITLE
Improved installation guide

### DIFF
--- a/pages/docs/getting-started/five-minute-guide-to-now.js
+++ b/pages/docs/getting-started/five-minute-guide-to-now.js
@@ -1,7 +1,7 @@
 import markdown from 'markdown-in-js'
 import withDoc, { components } from '../../../lib/with-doc'
 
-import { arunoda } from '../../../lib/data/team'
+import { arunoda, leo } from '../../../lib/data/team'
 import { TerminalInput } from '../../../components/text/terminal'
 import { Code } from '../../../components/text/code'
 import { HR } from '../../../components/text/paragraph'
@@ -12,7 +12,7 @@ import Now from '../../../components/now/now'
 export default withDoc({
   title: 'Five Minute Guide',
   date: '30 July 2017',
-  authors: [arunoda],
+  authors: [arunoda, leo],
 })(markdown(components)`
 
 With ${<Now color="#000"/>}, you can deploy and publish any kind of web app (or service) in under five minutes. This guide includes information about:
@@ -26,18 +26,17 @@ With ${<Now color="#000"/>}, you can deploy and publish any kind of web app (or 
 
 To use ${<Now color="#000"/>}, start by installing [Now Desktop](https://zeit.co/download).
 
-When the installation is completed, you can log in to ${<Now color="#000"/>} by running the following command using a terminal:
+When the installation is completed, you'll be asked to log in (or sign up) using your email address. Once that's done, you'll
+be guided through a tutorial which contains a section for easily installing Now CLI.
 
-${<TerminalInput>now login</TerminalInput>}
-
-Follow the instructions on the screen.<br/>
-(Since this is your first time, it will create an account for you.)
+After you've installed it, continue with the sections below (if the installation isn't working for some reason, there
+are [several other ways](https://zeit.co/download#command-line) to install Now CLI).
 
 ## Deployment
 
 Let's deploy a simple static web app.
 
-Create a directory called \`my-web-app\` and add the following content to a file called \`index.html\`.
+As the first step, create a directory called \`my-web-app\` and add the following content to a file called \`index.html\`.
 
 ${<Code>{`<!DOCTYPE html>
 <html>

--- a/pages/docs/getting-started/installation.js
+++ b/pages/docs/getting-started/installation.js
@@ -1,7 +1,7 @@
 import markdown from 'markdown-in-js'
 import withDoc, { components } from '../../../lib/with-doc'
 
-import { arunoda } from '../../../lib/data/team'
+import { arunoda, leo } from '../../../lib/data/team'
 import { TerminalInput } from '../../../components/text/terminal'
 import Image from '../../../components/image'
 import Now from '../../../components/now/now'
@@ -10,10 +10,13 @@ import Now from '../../../components/now/now'
 export default withDoc({
   title: 'Installation',
   date: '31 July 2017',
-  authors: [arunoda],
+  authors: [arunoda, leo],
 })(markdown(components)`
 
-In order to deploy to ${<Now color="#000"/>}, you need to install a small utility app. Let's see how you can do that.
+In order to deploy something, you need at least one of our applications: Now Desktop and/or Now CLI (the perfect
+scenerio is both being installed).
+
+This page will guide you through the differences and why both clients matter.
 
 ## Now Desktop (Recommended)
 
@@ -22,7 +25,7 @@ ${
     src={`${IMAGE_ASSETS_URL}/docs/installation/now-desktop.png`}
     width={550}
     height={380}
-    caption="Now Desktop on Mac OS"
+    caption="Now Desktop on macOS"
   />
 }
 
@@ -31,23 +34,22 @@ This is a desktop app which is [available](https://zeit.co/download) for all of 
 You can deploy apps, see notifications, and manage your account using an easy-to-use interface.
 It will update new versions automatically behind the scenes and you can always use the latest version of [Now Desktop](https://zeit.co/download).
 
-> Additionally, it comes with the \`now\` command line utility where you can interact with ${<Now color="#000"/>} using a terminal.
+In addition, it provides you with the ability to easily install Now CLI, which will then be kept up-to-date automatically.
 
 ## Now CLI
 
-This is the command line interface for ${<Now color="#000"/>}, especially built for [servers](https://zeit.co/download#command-line). It's a pre-built binary and works without any dependencies.
+Our command line interface provides you with the biggest range of features and lets you interact with
+our platform using commands.
 
-Now CLI is the ideal way to interact with ${<Now color="#000"/>} inside Continues Integration(CI) services.
+It is also the ideal way to interact with ${<Now color="#000"/>} inside Continues Integration (CI) services.
 
-## Now via NPM
-
-This is exactly Now CLI but distributed via [NPM](https://www.npmjs.com/). This method is ideal if your server environment already has NPM support.
-
-You can get this via the following command:
+You can install it like this...
 
 ${
   <TerminalInput>npm install -g now</TerminalInput>
 }
+
+...or [download the binaries](https://zeit.co/download#command-line) directly.
 
 ## Open Source
 


### PR DESCRIPTION
Now Desktop **does not** come with Now CLI (it needs to be installed manually). In turn, the current documentation was wrong and had to be fixed.

I also adjusted some other places in which we were telling people the wrong thing.