### PR TITLE
docs(travis): add node_modules when building app on Travis

### DIFF
--- a/pages/docs/continuous-integration/travis.js
+++ b/pages/docs/continuous-integration/travis.js
@@ -102,7 +102,7 @@ ${<Code>{
     "server",
     "static",
     "package.json",
-    "yarn.lock"
+    "node_modules"
   ],
   ...
 }


### PR DESCRIPTION
If you decide to build Next.js on Travis CI you will need to deploy `node_modules` folder to **now** instead of `*.lock` file.