### PR TITLE
Add caption to new Now Desktop image and make steps clearer

### DIFF
--- a/lib/data/last-edited.json
+++ b/lib/data/last-edited.json
@@ -37,7 +37,7 @@
   "pages/docs/getting-started/assign-a-domain-name.md": "2018-07-16T11:03:51.954Z",
   "pages/docs/getting-started/deployment.md": "2018-08-16T20:11:38.142Z",
   "pages/docs/getting-started/environment-variables.md": "2018-06-19T02:25:38.609Z",
-  "pages/docs/getting-started/five-minute-guide-to-now.md": "2018-08-18T22:31:38.000Z",
+  "pages/docs/getting-started/five-minute-guide-to-now.md": "2018-08-20T16:02:12.054Z",
   "pages/docs/getting-started/index.js": "2018-05-02T18:57:52.838Z",
   "pages/docs/getting-started/logs.md": "2018-08-16T20:11:38.143Z",
   "pages/docs/getting-started/scaling.md": "2018-08-16T20:11:38.144Z",

--- a/pages/docs/getting-started/five-minute-guide-to-now.md
+++ b/pages/docs/getting-started/five-minute-guide-to-now.md
@@ -5,6 +5,7 @@ import { leo, arunoda } from '../../../lib/data/team'
 import { TerminalInput } from '../../../components/text/terminal'
 import Image from '../../../components/image'
 import Now from '../../../components/now/now'
+import Caption from '../../../components/text/caption'
 
 
 export const meta = {
@@ -21,13 +22,14 @@ under five minutes.
 This quick-start guide will show you how to deploy an app, connect it to a
 domain name of your choice, and configure an SSL certificate.
 
-## Installing Now Desktop
+## Step 1: Installing Now Desktop
 
 <Image
   src={asset(`${IMAGE_ASSETS_URL}/docs/installation/now-desktop.png`)}
   width={600}
   height={500}
 />
+<Caption>Now Desktop running on macOS. Also available on Windows and Linux.</Caption>
 
 The best way to get started with Now on your device
 is by downloading [Now Desktop](https://zeit.co/download), a minimal application
@@ -41,7 +43,7 @@ on your account and teams that you've joined.
 simply dragging and dropping it onto its menubar icon or selecting
 it using a file picker.
 
-## Step 1: Signing Up
+## Step 2: Signing Up
 
 Once you've downloaded [Now Desktop](https://zeit.co/download) open it and follow the
 instructions.
@@ -49,7 +51,7 @@ instructions.
 After you've completed the signup process (you can also use the form
 to log in), a window should open with your account's event feed inside.
 
-## Step 2: Deploying a Static Site
+## Step 3: Deploying a Static Site
 
 Now that we're logged in, let's begin with deploying a
 simple static website.
@@ -82,7 +84,7 @@ After you have added the content, change to the `my-web-app` directory in your t
 
 This is a URL for the current deployment of the app. You can access this version of the app anytime with this URL.
 
-## Step 3: Configuring a Domain Name
+## Step 4: Configuring a Domain Name
 
 Now you have a unique URL (<https://my-web-app-avvuiuuwto.now.sh>) for your app. But you probably want a nicer-sounding URL to send your users to. The next step is to map the "now.sh" URL to a domain name that you prefer.
 
@@ -114,7 +116,7 @@ It is automatically configured with a [Let's Encrypt](https://letsencrypt.org/) 
   caption="After mapping a domain name to a deployment."
 />
 
-## Updates
+## Deploying Updates
 
 If you've made any changes to your app, you will need to deploy the latest version of your app. To do that, run this command:
 


### PR DESCRIPTION
This PR adds a caption to the image of Now Desktop to clarify that it is running on macOS but is available on other platforms. This PR also adds clearer step markers.