### PR TITLE
Changing "false" to a boolean on github config

### DIFF
--- a/pages/docs/integrations/now-for-github.md
+++ b/pages/docs/integrations/now-for-github.md
@@ -95,7 +95,7 @@ To disable Now for a GitHub repository, use the following configuration option i
 ```
 {
   "github": {
-    "enabled": "false"
+    "enabled": false
   }
 }
 ```


### PR DESCRIPTION
Using the current documentation causes an error `Error! Invalid request: config.github.enabled should be boolean`.

See error in action: https://travis-ci.org/PaulKinlan/paul.kinlan.me/builds/440568363#L696 and fix in https://travis-ci.org/PaulKinlan/paul.kinlan.me/builds/440570186

The correct solution is to ensure it is an actual boolean value. I've not tested things like `autoAlias` but I am presuming it is the same, but I will leave that to y'all to confirm.