### PR TITLE
developer-guide: fix useless code example

### DIFF
--- a/pages/docs/v2/deployments/builders/developer-guide.mdx
+++ b/pages/docs/v2/deployments/builders/developer-guide.mdx
@@ -97,7 +97,7 @@ exports.analyze = ({ files, entrypoint }) => files[entrypoint].digest;
 
 exports.build = async ({ files, entrypoint, config }) => {
   const stream = files[entrypoint].toStream();
-  const options = Object.assign({}, {}, config || {});
+  const options = Object.assign({}, config || {});
   const { data } = await FileBlob.fromStream({ stream });
   const content = data.toString();
 


### PR DESCRIPTION
Swapped `Object.assign({}, {}, …)` to just `Object.assign({}, …)`