### PR TITLE
Fixes eslint false positives.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
-node_modules
+.next
 deploy-server/node_modules
+dist
+pages/examples


### PR DESCRIPTION
After running `yarn dev`, `yarn build`, `yarn now-build`, or `yarn export` commands, the project would produce output that would cause eslint to either hang indefinitely or report false positives.

<img width="611" alt="screen shot 2018-12-27 at 12 52 03 pm" src="https://user-images.githubusercontent.com/446260/50491112-3cd8c000-09d6-11e9-9d85-7b8a73572e0a.png">

This PR adds the appropriate eslint ignores to stop these issues.