### PR TITLE
fix(#415): terminal link css typo

### DIFF
--- a/components/text/terminal.js
+++ b/components/text/terminal.js
@@ -99,7 +99,7 @@ export const TerminalLink = props => (
     <GenericLink {...props} />
     <style jsx>
       {`
-        span :gloabl(a) {
+        span :global(a) {
           text-decoration: underline;
         }
       `}

--- a/lib/data/last-edited.json
+++ b/lib/data/last-edited.json
@@ -182,7 +182,7 @@
   "pages/docs/v2/routing/compression.mdx": "2019-01-03T18:58:18.000Z",
   "pages/docs/v2/routing/directory-listing.mdx": "2019-01-04T22:52:33.000Z",
   "pages/docs/v2/routing/encryption.mdx": "2019-01-03T18:58:18.000Z",
-  "pages/docs/v2/routing/headers.mdx": "2019-01-21T01:10:06.000Z",
+  "pages/docs/v2/routing/headers.mdx": "2019-02-04T23:22:27.000Z",
   "pages/docs/v2/routing/overview.mdx": "2019-01-03T18:58:18.000Z",
   "pages/docs/v2/routing/status-codes.mdx": "2019-01-04T22:52:33.000Z",
   "pages/docs/version-config.js": "2018-11-15T01:11:50.000Z",


### PR DESCRIPTION
fixes #415 