### PR TITLE
Swap env for build.env property

### DIFF
--- a/pages/docs/v2/deployments/environment-variables-and-secrets.mdx
+++ b/pages/docs/v2/deployments/environment-variables-and-secrets.mdx
@@ -36,12 +36,14 @@ And just like defined before, the content of this global variable will be "test"
 
 The second way of defining environment variables is made specifically for the cases in which the content of the variables you'd like to define will stay the same for every new deployment.
 
-If that fits your project, simply add the [`env` property](/docs/v2/deployments/configuration#env) to your `now.json` file:
+If that fits your project, simply add the [`build.env` property](/docs/v2/deployments/configuration#build.env) to your `now.json` file:
 
 ```json
 {
-  "env": {
-    "DATABASE_NAME": "test"
+  "build": {
+    "env": {
+      "DATABASE_NAME": "test"
+    }
   }
 }
 ```


### PR DESCRIPTION
I can't get the example in the docs working. I have to use the `build.env` property when I deploy to Now for the env to be available. More information here: https://spectrum.chat/zeit/now/now-for-github-environnement-variables~53b07b7c-d33e-411d-b084-ced80b67dad2.

Maybe I have miss understood something...

Edit:

Actually I have to use the env property to get it working locally with [now-env](https://github.com/zeit/now-env). And the env.build to get it working with now. So I guess I miss understood something. Pretty weird to need both IMO.

```
{
       "env": {
		"DATABASE_NAME": "test"
	},
	"build": {
		"env": {
			"DATABASE_NAME": "test"
		}
	}
}
```