### PR TITLE
Update TLS support

### DIFF
--- a/pages/docs/api/v2/api-docs-mdx/api-basics/server-specs.mdx
+++ b/pages/docs/api/v2/api-docs-mdx/api-basics/server-specs.mdx
@@ -12,6 +12,6 @@ If requests are desired to hit a certain location, however, the API can be acces
 
 The API supports HTTP versions 1, 1.1, and 2, although HTTP/2 is preferred.
 
-TLS 1.1 and 1.2 are supported, although TLS protocol 1.2 is recommended.
+Both TLS 1.2 and 1.3 are supported.
 
 For more information on TLS support, refer to the [SSL Labs report](https://www.ssllabs.com/ssltest/analyze.html?d=api.zeit.co&hideResults=on&latest).

--- a/pages/docs/v2/routing/encryption.mdx
+++ b/pages/docs/v2/routing/encryption.mdx
@@ -28,7 +28,7 @@ It is not possible to disable this redirection or prevent the **Deployment** fro
 
 ## Supported TLS Versions
 
-Depending on what version of TLS your client making requests to your **Deployment** supports, we offer a range of releases to be compatible: [1.1](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.1), [1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.2) and [1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3).
+Depending on what version of TLS your client making requests to your **Deployment** supports, we offer a couple of releases to be compatible: [1.2](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.2) and [1.3](https://en.wikipedia.org/wiki/Transport_Layer_Security#TLS_1.3).
 
 ## Supported Ciphers
 


### PR DESCRIPTION
This pull request removes TLS 1.1 from being listed as supported in the documentation. As requested.

Fixes #518 