### PR TITLE
Specifying the specific PHP version

### DIFF
--- a/pages/docs/v2/deployments/official-builders/php-now-php.mdx
+++ b/pages/docs/v2/deployments/official-builders/php-now-php.mdx
@@ -63,7 +63,7 @@ All standard PHP variables like `$_GET`, `$_POST` are supported, with the except
 
 ### Version
 
-PHP 7 is implemented via the `go-php` package and bundled as a Go binary.
+PHP 7.1.x is implemented via the `go-php` package and bundled as a Go binary.
 
 ### Maximum Lambda Bundle Size
 


### PR DESCRIPTION
Defined in: https://github.com/zeit/now-builders/blob/master/packages/now-php-bridge/build/Dockerfile#L4

Note, this would be better if this value was configurable.

PHP 7.2 and 7.3 are released now as well.