### PR TITLE
add example @now/node example using express

### DIFF
--- a/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
+++ b/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
@@ -13,7 +13,7 @@ export const meta = {
   description:
     'The official Node.js Builder for ZEIT Now. Deploy serverless Node.js applications with ease.',
   editUrl: 'pages/docs/v2/deployments/official-builders/node-js-now-node.mdx',
-  lastEdited: '2019-03-12T15:18:33.000Z'
+  lastEdited: '2019-03-21T15:28:29.000Z'
 }
 
 <Tag>Status: Stable</Tag>
@@ -182,6 +182,30 @@ The Node.js version used is the latest in the **8 branch**.
 ### Request and Response Objects
 
 For each invocation of a Node.js lambda, two objects, request and response, are passed to the function. These objects are the standard HTTP [request](https://nodejs.org/api/http.html#http_event_request) and [response](https://nodejs.org/api/http.html#http_class_http_serverresponse) objects given and used by Node.js.
+
+Because many web serving frameworks like [express](http://expressjs.com/) also frequently deal with standard HTTP request and response objects, you may be able to use them in your Node.js lambda. The following lambda accepts a JSON body in the POST request, and returns a stringified version of it.
+
+<Example>
+  <span>Example Node.js lambda using express and body-parser</span>
+  <Code lang="javascript">{`'use strict'\n
+const express = require('express')
+const bodyParser = require('body-parser')\n
+const app = express()
+module.exports = app\n
+app.use(bodyParser.json())\n
+app.post('*', (req, res) => {
+  if (req.body == null) {
+    return res.send(400, { error: 'no JSON object in the request' })
+  }\n
+  res.set('Content-Type', 'application/json')
+  res.send(200, JSON.stringify(req.body, null, 4))
+})\n
+app.all('*', (req, res) => {
+  res.send(405, { error: 'only POST requests are accepted' })
+})`}</Code>
+</Example>
+
+For a further example, see the blog post [Serverless Express.js with Now 2](https://zeit.co/blog/serverless-express-js-lambdas-with-now-2).
 
 ### Maximum Lambda Bundle Size
 

--- a/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
+++ b/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
@@ -13,7 +13,7 @@ export const meta = {
   description:
     'The official Node.js Builder for ZEIT Now. Deploy serverless Node.js applications with ease.',
   editUrl: 'pages/docs/v2/deployments/official-builders/node-js-now-node.mdx',
-  lastEdited: '2019-03-21T15:28:29.000Z'
+  lastEdited: '2019-03-21T18:25:21.000Z'
 }
 
 <Tag>Status: Stable</Tag>
@@ -183,7 +183,7 @@ The Node.js version used is the latest in the **8 branch**.
 
 For each invocation of a Node.js lambda, two objects, request and response, are passed to the function. These objects are the standard HTTP [request](https://nodejs.org/api/http.html#http_event_request) and [response](https://nodejs.org/api/http.html#http_class_http_serverresponse) objects given and used by Node.js.
 
-Because many web serving frameworks like [express](http://expressjs.com/) also frequently deal with standard HTTP request and response objects, you may be able to use them in your Node.js lambda. The following lambda accepts a JSON body in the POST request, and returns a stringified version of it.
+With many Node.js-based frameworks like [Express](http://expressjs.com/) also frequently dealing with these HTTP request and response objects, you may be able to use them in your Node.js lambda. The following lambda example, using Express, accepts a JSON body in the POST request, and returns a stringified version of it.
 
 <Example>
   <span>Example Node.js lambda using express and body-parser</span>
@@ -205,7 +205,7 @@ app.all('*', (req, res) => {
 })`}</Code>
 </Example>
 
-For a further example, see the blog post [Serverless Express.js with Now 2](https://zeit.co/blog/serverless-express-js-lambdas-with-now-2).
+For more information, see the following examples: [Express](/examples/express/) and [Twitter Dreamify with Express](/examples/express-twitter-dreamify/).
 
 ### Maximum Lambda Bundle Size
 


### PR DESCRIPTION
Adds a small example showing how to use express and body-parser with the @now/node builder.