### PR TITLE
escape the example string so ${new Date()} won't be parsed

### DIFF
--- a/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
+++ b/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
@@ -13,7 +13,7 @@ export const meta = {
   description:
     'The official Node.js Builder for ZEIT Now. Deploy serverless Node.js applications with ease.',
   editUrl: 'pages/docs/v2/deployments/official-builders/node-js-now-node.mdx',
-  lastEdited: '2019-03-21T23:45:35.000Z'
+  lastEdited: '2019-04-09T16:21:26.000Z'
 }
 
 <Tag>Status: Stable</Tag>
@@ -144,7 +144,7 @@ You can run build tasks by creating a `now-build` script within a `package.json`
 <Code lang="javascript">{`const fs = require('fs');
   fs.writeFile(
   'built-time.js',
-  \`module.exports = "${new Date()}"\`,
+  \`module.exports = "\${new Date()}"\`,
   (err) => {
     if (err) throw err
     console.log('Build time file created successfully!')


### PR DESCRIPTION
escape the example string so ${new Date()} won't be parsed in the example into actual date