### PR TITLE
Update Guides for now dev

### DIFF
--- a/pages/guides/deploying-charge-with-now.mdx
+++ b/pages/guides/deploying-charge-with-now.mdx
@@ -16,7 +16,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Charge%20site**%20with%20Now.png?theme=light&md=1&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F25151dcf9878a3c40b686628cc84c9292d95ca0e%2F9e22f%2Fimages%2Flogomark.svg',
   editUrl: 'pages/guides/deploying-charge-with-now.mdx',
-  lastEdited: '2019-04-30T20:33:15.000Z'
+  lastEdited: '2019-05-01T00:10:23.000Z'
 }
 
 [Charge](https://charge.js.org/) is an opinionated, zero-config static site generator written in JavaScript. Charge is fast, simple and behaves the way you expect it to.
@@ -72,6 +72,10 @@ Now, make an addition to `package.json`, as recommended by the [Charge documenta
 </Caption>
 
 These scripts enable you to run a [local development server](/docs/v2/development/basics/) with `now dev` and, as you will see later on, [build](/docs/v2/deployments/builds/) your Charge site before [deploying](/docs/v2/deployments/basics/) with `now`.
+
+The [`@now/static-build` Builder](/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development) supports a custom `now-dev` script that allows you to define [custom development behavior](/docs/v2/development/basics/#custom-development-environment) while gaining extra features that mimic the Now platform locally.
+
+<Note
 
 ## Step 2: Add Content To Your Charge Project
 

--- a/pages/guides/deploying-charge-with-now.mdx
+++ b/pages/guides/deploying-charge-with-now.mdx
@@ -16,7 +16,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Charge%20site**%20with%20Now.png?theme=light&md=1&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F25151dcf9878a3c40b686628cc84c9292d95ca0e%2F9e22f%2Fimages%2Flogomark.svg',
   editUrl: 'pages/guides/deploying-charge-with-now.mdx',
-  lastEdited: '2019-04-09T15:53:39.000Z'
+  lastEdited: '2019-04-30T19:38:35.000Z'
 }
 
 [Charge](https://charge.js.org/) is an opinionated, zero-config static site generator written in JavaScript. Charge is fast, simple and behaves the way you expect it to.
@@ -45,7 +45,7 @@ Next, [initialize](https://yarnpkg.com/lang/en/docs/cli/init/) the project:
 
 <TerminalInput>yarn init</TerminalInput>
 <Caption>
-  Initialising the project, this creates a <InlineCode>package.json</InlineCode>{' '}file.
+  Initializing the project, this creates a <InlineCode>package.json</InlineCode>{' '}file.
 </Caption>
 
 Yarn will present some initial questions to set up your project, complete this and when done, add Charge as a [development dependency](https://yarnpkg.com/en/docs/cli/add#toc-yarn-add-dev-d):
@@ -60,7 +60,7 @@ Now, make an addition to `package.json`, as recommended by the [Charge documenta
 ```json
 {
   "scripts": {
-    "start": "charge serve src",
+    "now-dev": "charge serve src",
     "build": "charge build src dist"
   }
 }
@@ -71,7 +71,7 @@ Now, make an addition to `package.json`, as recommended by the [Charge documenta
   <InlineCode>package.json</InlineCode> file.
 </Caption>
 
-These scripts enable you to run a local development server with `yarn start` and, as you will see later on, [build](/docs/v2/deployments/builds/) your Charge site before [deploying](/docs/v2/deployments/basics/) with `now`.
+These scripts enable you to run a [local development server](/docs/v2/development/basics/) with `now dev` and, as you will see later on, [build](/docs/v2/deployments/builds/) your Charge site before [deploying](/docs/v2/deployments/basics/) with `now`.
 
 ## Step 2: Add Content To Your Charge Project
 
@@ -127,7 +127,7 @@ export default ({ children }) => {
 
 If, at any point, you want to see how your changes look, you can serve them locally with the script we added in the first step:
 
-<TerminalInput>yarn start</TerminalInput>
+<TerminalInput>now dev</TerminalInput>
 <Caption>
   Starting up a local development server using a script.
 </Caption>

--- a/pages/guides/deploying-charge-with-now.mdx
+++ b/pages/guides/deploying-charge-with-now.mdx
@@ -16,7 +16,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Charge%20site**%20with%20Now.png?theme=light&md=1&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F25151dcf9878a3c40b686628cc84c9292d95ca0e%2F9e22f%2Fimages%2Flogomark.svg',
   editUrl: 'pages/guides/deploying-charge-with-now.mdx',
-  lastEdited: '2019-05-01T00:10:23.000Z'
+  lastEdited: '2019-05-01T00:18:43.000Z'
 }
 
 [Charge](https://charge.js.org/) is an opinionated, zero-config static site generator written in JavaScript. Charge is fast, simple and behaves the way you expect it to.
@@ -74,8 +74,6 @@ Now, make an addition to `package.json`, as recommended by the [Charge documenta
 These scripts enable you to run a [local development server](/docs/v2/development/basics/) with `now dev` and, as you will see later on, [build](/docs/v2/deployments/builds/) your Charge site before [deploying](/docs/v2/deployments/basics/) with `now`.
 
 The [`@now/static-build` Builder](/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development) supports a custom `now-dev` script that allows you to define [custom development behavior](/docs/v2/development/basics/#custom-development-environment) while gaining extra features that mimic the Now platform locally.
-
-<Note
 
 ## Step 2: Add Content To Your Charge Project
 

--- a/pages/guides/deploying-charge-with-now.mdx
+++ b/pages/guides/deploying-charge-with-now.mdx
@@ -16,7 +16,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Charge%20site**%20with%20Now.png?theme=light&md=1&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F25151dcf9878a3c40b686628cc84c9292d95ca0e%2F9e22f%2Fimages%2Flogomark.svg',
   editUrl: 'pages/guides/deploying-charge-with-now.mdx',
-  lastEdited: '2019-04-30T19:38:35.000Z'
+  lastEdited: '2019-04-30T20:33:15.000Z'
 }
 
 [Charge](https://charge.js.org/) is an opinionated, zero-config static site generator written in JavaScript. Charge is fast, simple and behaves the way you expect it to.
@@ -125,7 +125,7 @@ export default ({ children }) => {
   An example <InlineCode>layout.html.jsx</InlineCode> file in a Charge project.
 </Caption>
 
-If, at any point, you want to see how your changes look, you can serve them locally with the script we added in the first step:
+If, at any point, you want to see how your changes look, you can [serve them locally](/docs/v2/development/basics/) with the script you added in the first step:
 
 <TerminalInput>now dev</TerminalInput>
 <Caption>

--- a/pages/guides/deploying-gatsby-with-now.mdx
+++ b/pages/guides/deploying-gatsby-with-now.mdx
@@ -14,7 +14,7 @@ export const meta = {
   authors: ['timothy'],
   url: '/guides/deploying-gatsby-with-now',
   editUrl: 'pages/guides/deploying-gatsby-with-now.mdx',
-  lastEdited: '2019-04-30T19:38:35.000Z'
+  lastEdited: '2019-05-01T00:10:23.000Z'
 }
 
 [Gatsby](https://www.gatsbyjs.org) is a popular front-end framework that helps you create static apps and websites with React.
@@ -49,6 +49,8 @@ At this point you you add a `now-dev` script to your `package.json` file. This w
   Adding a <InlineCode>now dev</InlineCode> script to the{' '}
   <InlineCode>package.json</InlineCode> file.
 </Caption>
+
+The [`@now/static-build` Builder](/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development) supports a custom `now-dev` script that allows you to define [custom development behavior](/docs/v2/development/basics/#custom-development-environment) while gaining extra features that mimic the Now platform locally.
 
 To run your project locally, all that's required is a **single command**:
 

--- a/pages/guides/deploying-gatsby-with-now.mdx
+++ b/pages/guides/deploying-gatsby-with-now.mdx
@@ -14,7 +14,7 @@ export const meta = {
   authors: ['timothy'],
   url: '/guides/deploying-gatsby-with-now',
   editUrl: 'pages/guides/deploying-gatsby-with-now.mdx',
-  lastEdited: '2019-02-01T21:22:01.000Z'
+  lastEdited: '2019-04-30T19:38:35.000Z'
 }
 
 [Gatsby](https://www.gatsbyjs.org) is a popular front-end framework that helps you create static apps and websites with React.
@@ -33,9 +33,26 @@ Then you can run the following command to create a Gatsby project locally:
 <TerminalInput>gatsby new my-gatsby-project</TerminalInput>
 <Caption>Creating a Gatsby project by creating the <InlineCode>my-gatsby-project</InlineCode> directory and generating content within it with gatsby-cli.</Caption>
 
-You can then see your new project running locally by running:
+At this point you you add a `now-dev` script to your `package.json` file. This will allow you to [replicate the Now environment locally](/docs/v2/development/basics/):
 
-<TerminalInput>gatsby develop</TerminalInput>
+```json
+{
+  ...
+  "scripts": {
+    ...
+    "now-dev": "gatsby develop -p $PORT",
+  }
+}
+```
+
+<Caption>
+  Adding a <InlineCode>now dev</InlineCode> script to the{' '}
+  <InlineCode>package.json</InlineCode> file.
+</Caption>
+
+To run your project locally, all that's required is a **single command**:
+
+<TerminalInput>now dev</TerminalInput>
 
 ## Step 2: Deploying Your Gatsby Website with Now
 
@@ -63,7 +80,7 @@ This now.json file will allow your deployment to do several things, specifically
 - Set [the project name](/docs/v2/deployments/configuration#name) to "my-gatsby-project".
 - Use [the @now/static-build Builder](/docs/v2/deployments/official-builders/static-build-now-static-build) to take the `package.json` file as an entrypoint and use the `public` directory as your content directory.
 
-The @now/static-build Builder you added requires a script to be included in the `package.json` you provided as the entrypoint. This script can be added to the end of the array of scripts that Gatsby CLI created for us:
+The @now/static-build Builder you added requires a script to be included in the `package.json` you provided as the entrypoint. This script can be added to the end of the array of scripts that Gatsby CLI created for us as you did earlier with `now-dev`:
 
 ```json
 {

--- a/pages/guides/deploying-react-with-now-cra.mdx
+++ b/pages/guides/deploying-react-with-now-cra.mdx
@@ -14,7 +14,7 @@ export const meta = {
   authors: ['timothy', 'grovesjoseph'],
   url: '/guides/deploying-react-with-now-cra',
   editUrl: 'pages/guides/deploying-react-with-now-cra.mdx',
-  lastEdited: '2019-04-30T19:38:35.000Z'
+  lastEdited: '2019-05-01T00:10:23.000Z'
 }
 
 React is a popular open-source JavaScript framework, maintained by Facebook, for easily creating interactive single-page applications (SPAs).
@@ -46,6 +46,8 @@ Once you have set up a React project with Create React App, you will be presente
   }
 }
 ```
+
+The [`@now/static-build` Builder](/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development) supports a custom `now-dev` script that allows you to define [custom development behavior](/docs/v2/development/basics/#custom-development-environment) while gaining extra features that mimic the Now platform locally.
 
 Now, with **just a single command**, you can simulate the Now environment locally:
 

--- a/pages/guides/deploying-react-with-now-cra.mdx
+++ b/pages/guides/deploying-react-with-now-cra.mdx
@@ -14,7 +14,7 @@ export const meta = {
   authors: ['timothy', 'grovesjoseph'],
   url: '/guides/deploying-react-with-now-cra',
   editUrl: 'pages/guides/deploying-react-with-now-cra.mdx',
-  lastEdited: '2019-03-08T17:50:24.000Z'
+  lastEdited: '2019-04-30T19:38:35.000Z'
 }
 
 React is a popular open-source JavaScript framework, maintained by Facebook, for easily creating interactive single-page applications (SPAs).
@@ -36,10 +36,21 @@ A fast method of setting up with CRA is to use [Yarn](https://yarnpkg.com) in yo
 
 If you would prefer to use another method, see the [Quick Start documentation for CRA](https://facebook.github.io/create-react-app/docs/getting-started#quick-start).
 
-Once you have set up a React project with Create React App, you will be presented with information, one piece of which will tell you that you can now start your local development server with the following command:
+Once you have set up a React project with Create React App, you will be presented with information, one piece of which will tell you that you can now start your local development server. To replicate the [Now environment locally](/docs/v2/development/basics/), you should add the following script to your `package.json` file:
 
-<TerminalInput>yarn start</TerminalInput>
-<Caption>Starting a local development server for React with generated scripts from Create React App.</Caption>
+```json
+{
+  "scripts": {
+    ...
+    "now-dev": "react-scripts start"
+  }
+}
+```
+
+Now, with **just a single command**, you can simulate the Now environment locally:
+
+<TerminalInput>now dev</TerminalInput>
+<Caption>Running the Now environment locally with a single command.</Caption>
 
 You can now start developing your React application while testing it on your local server.
 

--- a/pages/guides/deploying-vuejs-to-now.mdx
+++ b/pages/guides/deploying-vuejs-to-now.mdx
@@ -15,7 +15,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Vue.js%20App**%20with%20Now.png?theme=light&md=1&fontSize=96px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Fv1551318573%2Ffront%2Fdocs%2Fogp%2Fvue-logo.svg',
   editUrl: 'pages/guides/deploying-vuejs-to-now.mdx',
-  lastEdited: '2019-04-30T19:38:35.000Z'
+  lastEdited: '2019-05-01T00:10:23.000Z'
 }
 
 Vue.js is an open source JavaScript framework for building user interfaces. It is popularly known for its gentle learning curve and is adopted by a lot of developers for crafting single-page applications (SPAs) globally.
@@ -55,6 +55,8 @@ To see your new Vue.js project running, you should add a `now-dev` script to you
   Adding a <InlineCode>now dev</InlineCode> script to the{' '}
   <InlineCode>package.json</InlineCode> file.
 </Caption>
+
+The [`@now/static-build` Builder](/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development) supports a custom `now-dev` script that allows you to define [custom development behavior](/docs/v2/development/basics/#custom-development-environment) while gaining extra features that mimic the Now platform locally.
 
 To run your project locally, all that's required is a **single command**:
 

--- a/pages/guides/deploying-vuejs-to-now.mdx
+++ b/pages/guides/deploying-vuejs-to-now.mdx
@@ -15,7 +15,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Vue.js%20App**%20with%20Now.png?theme=light&md=1&fontSize=96px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Fv1551318573%2Ffront%2Fdocs%2Fogp%2Fvue-logo.svg',
   editUrl: 'pages/guides/deploying-vuejs-to-now.mdx',
-  lastEdited: '2019-02-28T02:00:22.000Z'
+  lastEdited: '2019-04-30T19:38:35.000Z'
 }
 
 Vue.js is an open source JavaScript framework for building user interfaces. It is popularly known for its gentle learning curve and is adopted by a lot of developers for crafting single-page applications (SPAs) globally.
@@ -40,9 +40,25 @@ An option to choose a preset will be presented to you after running the command 
 
 After choosing an option, Vue CLI installs all the required dependencies and provisions a new project for you.
 
-To see your new Vue.js project running, you can use the following command to start a development server locally:
+To see your new Vue.js project running, you should add a `now-dev` script to your `package.json`, this will allow you to [replicate the Now environment locally](/docs/v2/development/basics/):
 
-<TerminalInput>yarn serve</TerminalInput>
+```json
+{
+  "scripts": {
+    ...
+    "now-dev": "vue-cli-service serve  --port=$PORT"
+  }
+}
+```
+
+<Caption>
+  Adding a <InlineCode>now dev</InlineCode> script to the{' '}
+  <InlineCode>package.json</InlineCode> file.
+</Caption>
+
+To run your project locally, all that's required is a **single command**:
+
+<TerminalInput>now dev</TerminalInput>
 
 Next, to extend the project with routing; install the [official Vue.js router](https://router.vuejs.org/) by running the following command in your terminal:
 

--- a/pages/guides/deploying-vuepress-to-now.mdx
+++ b/pages/guides/deploying-vuepress-to-now.mdx
@@ -11,7 +11,7 @@ export const meta = {
   authors: ['unicodeveloper'],
   url: '/guides/deploying-vuepress-to-now',
   editUrl: 'pages/guides/deploying-vuepress-to-now.mdx',
-  lastEdited: '2019-04-30T19:38:35.000Z'
+  lastEdited: '2019-04-30T19:42:58.000Z'
 }
 
 VuePress is a vue-powered static generator. It is used for generating static sites with a focus on writing.
@@ -66,14 +66,13 @@ module.exports = {
   A <InlineCode>config.js</InlineCode> configuration file.
 </Caption>
 
-Next, add some scripts to the `package.json` file in the root project directory.
+Next, add some development scripts to the `package.json` file in the root project directory.
 
 ```js
 {
     ...
     "scripts": {
       "dev": "vuepress dev",
-      "build": "vuepress build",
       "now-dev": "vuepress dev docs --port=$PORT"
     }
 }
@@ -120,7 +119,7 @@ Next, we need to add a script in the `package.json` file that specifies the comm
     "scripts": {
         ...
         "build": "vuepress build",
-        "now-build": "vuepress build"
+        "now-build": "npm run build && mv docs/.vuepress/dist dist"
     }
 }
 ```

--- a/pages/guides/deploying-vuepress-to-now.mdx
+++ b/pages/guides/deploying-vuepress-to-now.mdx
@@ -11,7 +11,7 @@ export const meta = {
   authors: ['unicodeveloper'],
   url: '/guides/deploying-vuepress-to-now',
   editUrl: 'pages/guides/deploying-vuepress-to-now.mdx',
-  lastEdited: '2019-04-30T19:42:58.000Z'
+  lastEdited: '2019-05-01T00:10:23.000Z'
 }
 
 VuePress is a vue-powered static generator. It is used for generating static sites with a focus on writing.
@@ -81,6 +81,8 @@ Next, add some development scripts to the `package.json` file in the root projec
 <Caption>
   Adding scripts to a <InlineCode>package.json</InlineCode> file.
 </Caption>
+
+The [`@now/static-build` Builder](/docs/v2/deployments/official-builders/static-build-now-static-build/#local-development) supports a custom `now-dev` script that allows you to define [custom development behavior](/docs/v2/development/basics/#custom-development-environment) while gaining extra features that mimic the Now platform locally.
 
 Now, you can run VuePress by [replicating the Now environment locally](/docs/v2/development/basics/) with a single command:
 

--- a/pages/guides/deploying-vuepress-to-now.mdx
+++ b/pages/guides/deploying-vuepress-to-now.mdx
@@ -11,7 +11,7 @@ export const meta = {
   authors: ['unicodeveloper'],
   url: '/guides/deploying-vuepress-to-now',
   editUrl: 'pages/guides/deploying-vuepress-to-now.mdx',
-  lastEdited: '2019-02-26T13:27:30.000Z'
+  lastEdited: '2019-04-30T19:38:35.000Z'
 }
 
 VuePress is a vue-powered static generator. It is used for generating static sites with a focus on writing.
@@ -66,7 +66,7 @@ module.exports = {
   A <InlineCode>config.js</InlineCode> configuration file.
 </Caption>
 
-Next, add some VuePress scripts to the `package.json` file in the root project directory.
+Next, add some scripts to the `package.json` file in the root project directory.
 
 ```js
 {
@@ -74,17 +74,18 @@ Next, add some VuePress scripts to the `package.json` file in the root project d
     "scripts": {
       "dev": "vuepress dev",
       "build": "vuepress build",
+      "now-dev": "vuepress dev docs --port=$PORT"
     }
 }
 ```
 
 <Caption>
-  A <InlineCode>package.json</InlineCode> file.
+  Adding scripts to a <InlineCode>package.json</InlineCode> file.
 </Caption>
 
-Now, you can run VuePress with the following command:
+Now, you can run VuePress by [replicating the Now environment locally](/docs/v2/development/basics/) with a single command:
 
-<TerminalInput>yarn dev</TerminalInput>
+<TerminalInput>now dev</TerminalInput>
 
 ## Step 3: Deploy VuePress with Now
 


### PR DESCRIPTION
This PR adds support for `now env` in all guides where a static builder is used. The correct scripts have been tested as per the [now examples](https://github.com/zeit/now-examples) repository.