### PR TITLE
v10.x is not supported by the node builder

### DIFF
--- a/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
+++ b/pages/docs/v2/deployments/official-builders/node-js-now-node.mdx
@@ -180,6 +180,8 @@ The resulting lambda contains both the build and current time: <https://build-ti
 
 The Node.js version used is the **v8.10**.
 
+At the moment, **v10.x** is not supported. [Source](https://spectrum.chat/zeit/general/how-to-set-node-version-on-v2~56864992-ffa1-4211-ba8e-118941d4739e)
+
 ### Request and Response Objects
 
 For each invocation of a Node.js lambda, two objects, request and response, are passed to the function. These objects are the standard HTTP [request](https://nodejs.org/api/http.html#http_event_request) and [response](https://nodejs.org/api/http.html#http_class_http_serverresponse) objects given and used by Node.js.


### PR DESCRIPTION
node 10 is not supported by the node builder.  The previous example said that only v8.1 is supported without any other information regarding other versions.

I added the clarification that node 10 support is not present and provided a link to the spectrum chat as stated by @paulogdm .

Link is as follows: https://spectrum.chat/zeit/general/how-to-set-node-version-on-v2~56864992-ffa1-4211-ba8e-118941d4739e