### PR TITLE
👌 IMPROVE: List Deployments with `teamId`

### DIFF
--- a/pages/docs/api/v2/api-docs-mdx/endpoints/deployments.mdx
+++ b/pages/docs/api/v2/api-docs-mdx/endpoints/deployments.mdx
@@ -449,6 +449,7 @@ The response of this API can be controlled with the following query parameters. 
 | -------------- | -------------------------------------------------------------------------------------------------- |
 | **limit**      | Maximum number of deployments to list from a request. (default: 5, max: 100)                       |
 | **from**       | Get the deployment created after this [Date](#api-basics/types) timestamp. (default: current time) |
+| **teamId**     | List deployments of the team matching the specified `teamId`.                                                     |
 | **projectId**  | Filter deployments from the given `projectId`.                                                     |
 | **meta-[KEY]** | Filter deployments by the given meta key value pairs. e.g., `meta-githubDeployment=1`.             |
 


### PR DESCRIPTION
The API documentation is missing an important parameter `teamId` that allows people to list deployments based on a specified `teamId`.

Context [Discussion on Twitter](https://twitter.com/MrAhmadAwais/status/1139718673684402176).

Peace! ✌️ 