### PR TITLE
remove next.config.js from deploying-nextjs-with-now

### DIFF
--- a/pages/guides/deploying-nextjs-with-now.mdx
+++ b/pages/guides/deploying-nextjs-with-now.mdx
@@ -129,18 +129,6 @@ export default function HomePage() {
   An <InlineCode>index.js</InlineCode> file for your Next.js project.
 </Caption>
 
-Lastly, create a `next.config.js` file at the root of your project, this file tells Next.js to target a serverless build environment:
-
-```js
-module.exports = {
-  target: 'serverless'
-}
-```
-
-<Caption>
-  A <InlineCode>next.config.js</InlineCode> file for your Next.js project.
-</Caption>
-
 ### Adding `now.json` and `.nowignore`
 
 To provide [configuration for your project](/docs/v2/deployments/configuration/), you should use a `now.json` file.
@@ -186,7 +174,7 @@ For this project, you will require the use of a single Builder, [`@now/next`](/d
 {
   ...
   "builds": [
-    { "src": "next.config.js", "use": "@now/next" }
+    { "src": "package.json", "use": "@now/next" }
   ]
 }
 ```


### PR DESCRIPTION
It seems next 9 no longer requires creating the `next.config.js` file. I've deleted this section and changed the builder src file to `package.json`. Does this look correct?