### PR TITLE
Update deploying angular with now

### DIFF
--- a/pages/guides/deploying-angular-with-now.mdx
+++ b/pages/guides/deploying-angular-with-now.mdx
@@ -59,7 +59,13 @@ After a successful scaffolding, `cd` into `my-new-app` directory and run the fol
 
 Your browser will automatically be launched with the served Angular app at <http://localhost:4200/>
 
-## Step 2: Deploy Your Angular Project with Now
+## Step 3: Install the 'serve' package using the following command: `npm install --save-dev serve`
+
+## Step 4: Update the script in package.json file:
+ "start": "serve dist/ --single",
+   "build": "ng build --prod",
+
+## Step 5: Deploy Your Angular Project with Now
 
 With your Angular application set up, it is ready to deploy live with [Now](/docs/v2).
 


### PR DESCRIPTION
The previous or current details in the official guide will not allow the angular project to be rendered, a common angular error about styles not being recognised is seen in the console.
In my quest for a solution, I discovered the 'serve' NPM package that handles serving the files in dist folder on the browser and alleviates the previous error.

TLDR Steps:
- Install now globally or within the project
- Install 'serve' within the project and save it as a dev dependency.
- Update package.json script
- Deploy the project by running now in the CLI