### PR TITLE
Guide for deploying Gatsby

### DIFF
--- a/pages/guides/deploying-gatsby-with-now.mdx
+++ b/pages/guides/deploying-gatsby-with-now.mdx
@@ -16,7 +16,7 @@ export const meta = {
 
 [Gatsby](https://www.gatsbyjs.org) is a popular front-end framework that helps you create static apps and websites with React.
 
-In this guide, we will show how you can set up your Gatsby project and deploy with Now in a few moments.
+In this guide, we will show you can set up your Gatsby project and deploy with Now in a few moments.
 
 ## Step 1: Set Up Your Gatsby Project
 

--- a/pages/guides/migrate-to-zeit-now.mdx
+++ b/pages/guides/migrate-to-zeit-now.mdx
@@ -16,7 +16,7 @@ export const meta = {
   lastEdited: '2019-08-23T14:21:42.000Z'
 }
 
-This guide highlights a set of common scenarios and how they are deployed with ZEIT Now.
+This guide highlights set of common scenarios and how they are deployed with ZEIT Now.
 
 ## Frontend Frameworks
 


### PR DESCRIPTION
With this pull request, a new guide called "Create a Gatsby Website and Deploy It with ZEIT Now" is added to the list of guides.

The guide – as the name suggests – explains how to easily deploy Gatsby to ZEIT Now.