### PR TITLE
Fixed chocolatey installation command.

### DIFF
--- a/pages/guides/deploying-hugo-with-now.mdx
+++ b/pages/guides/deploying-hugo-with-now.mdx
@@ -32,7 +32,7 @@ For macOS users, you can install Hugo via [Brew](https://brew.sh):
 
 For Windows users, you can install Hugo via [Chocolatey](https://chocolatey.org/):
 
-<Snippet dark text="choco install hugo-confirm" />
+<Snippet dark text="choco install hugo -confirm" />
 <Caption>Installing <GenericLink href="https://gohugo.io/getting-started/installing/">Hugo CLI</GenericLink> via <GenericLink href="https://chocolatey.org/">Chocolatey</GenericLink>.</Caption>
 
 Next, run the following command to create a Hugo project via the CLI:


### PR DESCRIPTION
According to https://gohugo.io/getting-started/installing/#chocolatey-windows the installation command should be "choco install hugo -confirm"