### PR TITLE
Remove Outdated Target/Alias Usage from Guides

### DIFF
--- a/lib/data/guides.json
+++ b/lib/data/guides.json
@@ -16,7 +16,7 @@
     "url": "/guides/deploying-a-mongodb-powered-api-with-node-and-now",
     "image": "undefined/guides/deploying-a-mongodb-powered-api-with-node-and-now/card.png",
     "editUrl": "pages/guides/deploying-a-mongodb-powered-api-with-node-and-now.mdx",
-    "lastEdited": "2019-08-23T14:21:42.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Create an Angular App That Builds and Deploys with ZEIT Now",
@@ -35,7 +35,7 @@
     "authors": ["unicodeveloper, msweeneydev"],
     "url": "/guides/deploying-apolloserver-to-now",
     "editUrl": "pages/guides/deploying-apolloserver-to-now.mdx",
-    "lastEdited": "2019-09-17T08:46:12.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Create a Charge App That Builds and Deploys with ZEIT Now",
@@ -45,7 +45,7 @@
     "url": "/guides/deploying-charge-with-now",
     "image": "https://og-image.now.sh/**Deploy%20a%20Charge%20site**%20with%20Now.png?theme=light&md=1&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F25151dcf9878a3c40b686628cc84c9292d95ca0e%2F9e22f%2Fimages%2Flogomark.svg",
     "editUrl": "pages/guides/deploying-charge-with-now.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Create a Gatsby Website and Deploy It with ZEIT Now",
@@ -54,7 +54,7 @@
     "authors": ["timothy"],
     "url": "/guides/deploying-gatsby-with-now",
     "editUrl": "pages/guides/deploying-gatsby-with-now.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Deploy Gridsome Sites with ZEIT Now",
@@ -64,7 +64,7 @@
     "url": "/guides/deploying-gridsome-with-zeit-now",
     "image": "https://og-image.now.sh/**Deploying%20Gridsome%20Sites**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fgridsome.org%2Flogos%2Fonly-logo.svg&widths=auto&widths=auto",
     "editUrl": "pages/guides/deploying-gridsome-with-zeit-now.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Create a Hugo Website and Deploy It with ZEIT Now",
@@ -73,7 +73,7 @@
     "authors": ["unicodeveloper"],
     "url": "/guides/deploying-hugo-with-now",
     "editUrl": "pages/guides/deploying-hugo-with-now.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Create a Next.js and Buttercms App That Builds and Deploys with ZEIT Now",
@@ -133,7 +133,7 @@
     "url": "/guides/deploying-nextjs-nodejs-and-faunadb-with-zeit-now",
     "image": "https://og-image.now.sh/**Deploy%20a%20FaunaDB-Powered%20Next.js%20app**%20%3Cbr%2F%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=70px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fzeit-black-triangle.svg&images=https%3A%2F%2Fseeklogo.com%2Fimages%2FN%2Fnext-js-logo-7929BCD36F-seeklogo.com.png&images=https%3A%2F%2Fres-3.cloudinary.com%2Fcrunchbase-production%2Fimage%2Fupload%2Fc_lpad%2Ch_256%2Cw_256%2Cf_auto%2Cq_auto%3Aeco%2Fywnzi0pt0uw9klatmadc",
     "editUrl": "pages/guides/deploying-nextjs-nodejs-and-faunadb-with-zeit-now.mdx",
-    "lastEdited": "2019-09-22T20:35:35.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Getting Started with Next.js and ZEIT Now",
@@ -143,7 +143,7 @@
     "url": "/guides/deploying-nextjs-with-now",
     "image": "https://og-image.now.sh/**Deploy%20Serverless%20Next.js**%20with%20Now.png?theme=light&md=1&fontSize=83px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg&heights=250&heights=350",
     "editUrl": "pages/guides/deploying-nextjs-with-now.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Deploying a Static Nuxt.js App with ZEIT Now",
@@ -163,7 +163,7 @@
     "url": "/guides/deploying-preact-with-zeit-now",
     "editUrl": "pages/guides/deploying-preact-with-zeit-now.mdx",
     "image": "https://og-image.now.sh/**Deploy%20a%20Preact%20App**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fwww.stickpng.com%2Fassets%2Fimages%2F584815e7cef1014c0b5e4978.png",
-    "lastEdited": "2019-09-30T09:35:44.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Deploying Real-Time Apps with Pusher Channels and ZEIT Now",
@@ -173,7 +173,7 @@
     "url": "/guides/deploying-pusher-channels-with-zeit-now",
     "image": "https://og-image.now.sh/**Deploy%20Pusher%20Channels%20Apps**%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=96px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fpusher-icon.now-examples.now.sh&widths=250&widths=300&heights=250&heights=250",
     "editUrl": "pages/guides/deploying-pusher-channels-with-zeit-now.mdx",
-    "lastEdited": "2019-09-17T08:46:12.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Deploying React Forms Using Formspree with ZEIT Now",
@@ -192,7 +192,7 @@
     "authors": ["timothy", "grovesjoseph"],
     "url": "/guides/deploying-react-with-now-cra",
     "editUrl": "pages/guides/deploying-react-with-now-cra.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Deploying Sanity Studio with ZEIT Now",
@@ -212,7 +212,7 @@
     "url": "/guides/deploying-statickit-with-zeit-now",
     "editUrl": "pages/guides/deploying-statickit-with-zeit-now.mdx",
     "image": "https://og-image.now.sh/**Deploy%20a%20StaticKit%20Project**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iNDYwcHgiIGhlaWdodD0iNDYwcHgiIHZpZXdCb3g9IjAgMCA0NjAgNDYwIiB2%250D%250AZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxp%250D%250Abms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPGcgc3Ryb2tlPSJub25lIiBz%250D%250AdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI%2BCiAgICAgICAg%250D%250APGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTAwLjAwMDAwMCwgMTAwLjAwMDAwMCkiIGZpbGw9IiMw%250D%250AMDAwMDAiIGZpbGwtcnVsZT0ibm9uemVybyI%2BCiAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLDAgTDI2%250D%250AMCwwIEwyNjAsNzYuNzgxMjUgTDI2MCwyNjAgTDAsMjYwIEwwLDAgWiBNMzAsMzAgTDMwLDIzMCBM%250D%250AMjMwLDIzMCBMMjMwLDMwIEwzMCwzMCBaIj48L3BhdGg%2BCiAgICAgICAgICAgIDxwb2x5Z29uIHRy%250D%250AYW5zZm9ybT0idHJhbnNsYXRlKDEzMC4wMDAwMDAsIDEzMC4wMDAwMDApIHJvdGF0ZSgtNDUuMDAw%250D%250AMDAwKSB0cmFuc2xhdGUoLTEzMC4wMDAwMDAsIC0xMzAuMDAwMDAwKSAiIHBvaW50cz0iNzAgMTQ1%250D%250AIDE5MCAxNDUgMTkwIDExNSA3MCAxMTUiPjwvcG9seWdvbj4KICAgICAgICA8L2c%2BCiAgICA8L2c%2B%250D%250ACjwvc3ZnPgo%3D&heights=200&heights=300",
-    "lastEdited": "2019-09-13T14:53:08.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Create a Svelte Component Library Using Storybook and Deploy It with ZEIT Now",
@@ -222,7 +222,7 @@
     "url": "/guides/deploying-storybook-with-zeit-now",
     "editUrl": "pages/guides/deploying-storybook-with-zeit-now.mdx",
     "image": "https://og-image.now.sh/**Deploy%20a%20Storybook%20Library**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F1100804485616566273%2FsOct-Txm_400x400.png",
-    "lastEdited": "2019-08-30T09:17:58.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Deploying a Vue.js App with ZEIT Now",
@@ -241,16 +241,16 @@
     "authors": ["unicodeveloper"],
     "url": "/guides/deploying-vuepress-to-now",
     "editUrl": "pages/guides/deploying-vuepress-to-now.mdx",
-    "lastEdited": "2019-09-30T18:53:49.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Automatic Deployments with Now for GitLab",
-    "description": "Setup ZEIT Now for GitLab and get automatic deployments and aliasing for each push.",
+    "description": "Setup ZEIT Now for GitLab and get automatic deployments and staging domains for each push.",
     "published": "2019-04-01T09:03:14.819Z",
     "authors": ["arunoda", "timothy"],
     "url": "/guides/getting-started-with-now-for-gitlab",
     "editUrl": "pages/guides/getting-started-with-now-for-gitlab.mdx",
-    "lastEdited": "2019-08-23T14:21:42.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Handling Node.js Request Bodies with ZEIT Now",
@@ -286,25 +286,25 @@
     "authors": ["timothy"],
     "url": "/guides/redirect-from-www",
     "editUrl": "pages/guides/redirect-from-www.mdx",
-    "lastEdited": "2019-09-13T14:50:12.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Setup a GoDaddy Domain with ZEIT Now",
-    "description": "Use your GoDaddy registered domain as an alias for your ZEIT Now deployments.",
+    "description": "Use your GoDaddy registered domain for your ZEIT Now deployments.",
     "published": "2019-01-23T17:00:00.860Z",
     "authors": ["timothy"],
     "url": "/guides/setup-godaddy-domain-now",
     "editUrl": "pages/guides/setup-godaddy-domain-now.mdx",
-    "lastEdited": "2019-08-23T14:21:42.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "Setup a Namecheap Domain with ZEIT Now",
-    "description": "Use your Namecheap registered domain as an alias for your ZEIT Now deployments.",
+    "description": "Use your Namecheap registered domain for your ZEIT Now deployments.",
     "published": "2019-02-15T17:00:00.860Z",
     "authors": ["unicodeveloper"],
     "url": "/guides/setup-namecheap-domain-now",
     "editUrl": "pages/guides/setup-namecheap-domain-now.mdx",
-    "lastEdited": "2019-08-23T14:21:42.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   },
   {
     "title": "How to Update Now CLI",
@@ -331,6 +331,6 @@
     "authors": ["msweeneydev"],
     "url": "/guides/zero-downtime-domain-migration",
     "editUrl": "pages/guides/zero-downtime-domain-migration.mdx",
-    "lastEdited": "2019-08-27T14:52:10.000Z"
+    "lastEdited": "2019-10-02T14:07:07.000Z"
   }
 ]

--- a/pages/guides/deploying-a-mongodb-powered-api-with-node-and-now.mdx
+++ b/pages/guides/deploying-a-mongodb-powered-api-with-node-and-now.mdx
@@ -17,7 +17,7 @@ export const meta = {
     process.env.ASSETS
   }/guides/deploying-a-mongodb-powered-api-with-node-and-now/card.png`,
   editUrl: 'pages/guides/deploying-a-mongodb-powered-api-with-node-and-now.mdx',
-  lastEdited: '2019-08-23T14:21:42.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 In this guide, we will walk you through creating and [deploying](/docs/v2/deployments/basics/) a [Node.js](https://nodejs.org/) API powered by [MongoDB](https://www.mongodb.com/), on [ZEIT Now](/now).
@@ -235,32 +235,12 @@ The next and final step is to deploy your app with a single command.
 
 With Now, you can deploy your app to [different environments](/docs/v2/custom-domains#deploying-with-your-domain), depending on what stage your app is at; either staging or production.
 
-To deploy to a unique alias, use the following [Now CLI](/download) command from your terminal:
+To deploy your MongoDB API, use the following [Now CLI](/download) command from your terminal:
 
 <Snippet dark text="now" />
 <Caption>Deploying with Now CLI in one command.</Caption>
 
-<Note hint>
-  See more ways to deploy and alias from the{' '}
-  <GenericLink href="/docs/v2/custom-domains#deploying-with-your-domain">
-    Aliasing Documentation.
-  </GenericLink>
-</Note>
-
-For [production deployments](/docs/v2/custom-domains#deploying-with-your-domain), you can deploy to an alias of your choice. To do so, add an `alias` to your `now.json` file:
-
-```json
-{
-  ...
-  "alias": "my-mongodb-api"
-  ...
-}
-```
-
-<Caption>
-  Extending a <InlineCode>now.json</InlineCode> file with an{' '}
-  <InlineCode>alias</InlineCode> property.
-</Caption>
+For [production deployments](/docs/v2/custom-domains#deploying-with-your-domain), you can deploy to a production domain of your choice. To do so, [add a custom domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) to your project.
 
 Now, deploy your project to a production environment using the following command:
 
@@ -278,15 +258,15 @@ Now, deploy your project to a production environment using the following command
   </GenericLink>.
 </Note>
 
-When complete, Now CLI will provide you with the URL your project has been deployed and aliased to. In the case above, the alias was set to `my-mongodb-api.now.sh`.
+When complete, Now CLI will provide you with the URL your project has been deployed to. In the case above, the production domain was set to `my-mongodb-api.now.sh`.
 
-You can view the aliased deployment from this guide, using the API path, here: <https://my-mongodb-api.now.sh/api/users.js>
+You can view the deployment from this guide, using the API path, here: <https://my-mongodb-api.now.sh/api/users.js>
 
 ## Deploying Automatically with Git
 
 Instead of deploying manually through your terminal, you can also get **automatic deployments with each git push** when you use [Now for GitHub](/github) or [Now for GitLab](/gitlab).
 
-Push to any branch, pull, or merge request and get a fresh deployment to review. Merging into the default branch results in an automatic alias to production. No extra work needed.
+Push to any branch, pull, or merge request and get a fresh deployment to review. Merging into the default branch results in an automatic update of the production domain. No extra work needed.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-apolloserver-to-now.mdx
+++ b/pages/guides/deploying-apolloserver-to-now.mdx
@@ -10,7 +10,7 @@ export const meta = {
   authors: ['unicodeveloper, msweeneydev'],
   url: '/guides/deploying-apolloserver-to-now',
   editUrl: 'pages/guides/deploying-apolloserver-to-now.mdx',
-  lastEdited: '2019-09-17T08:46:12.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 In this guide, we will be deploying an Apollo GraphQL server with ZEIT Now.
@@ -79,7 +79,7 @@ Deploying your project could not be easier and can be done with **a single comma
 
 Your project has now been deployed, you can access the Apollo Server endpoint, using the deployment URL generated, at `/api`.
 
-If you want to deploy your ApolloServer project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your ApolloServer project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-charge-with-now.mdx
+++ b/pages/guides/deploying-charge-with-now.mdx
@@ -15,7 +15,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20Charge%20site**%20with%20Now.png?theme=light&md=1&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fd33wubrfki0l68.cloudfront.net%2F25151dcf9878a3c40b686628cc84c9292d95ca0e%2F9e22f%2Fimages%2Flogomark.svg',
   editUrl: 'pages/guides/deploying-charge-with-now.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Charge](https://charge.js.org/) is an opinionated, zero-config static site generator written in JavaScript. Charge is fast, simple and behaves the way you expect it to.
@@ -206,7 +206,7 @@ You will see a short build step in your terminal followed by the news that your 
   , making your site fast to load wherever you are in the world.
 </Note>
 
-If you want to deploy your Charge project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Charge project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-gatsby-with-now.mdx
+++ b/pages/guides/deploying-gatsby-with-now.mdx
@@ -12,7 +12,7 @@ export const meta = {
   authors: ['timothy'],
   url: '/guides/deploying-gatsby-with-now',
   editUrl: 'pages/guides/deploying-gatsby-with-now.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Gatsby](https://www.gatsbyjs.org) is a popular front-end framework that helps you create static apps and websites with React.
@@ -49,7 +49,7 @@ Now allows you to [deploy your project](/docs/v2/deployments/basics) from the te
 
 <Caption>Deploying you Gatsby website with Now CLI.</Caption>
 
-If you want to deploy your Gatsby project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Gatsby project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-gridsome-with-zeit-now.mdx
+++ b/pages/guides/deploying-gridsome-with-zeit-now.mdx
@@ -13,7 +13,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploying%20Gridsome%20Sites**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fgridsome.org%2Flogos%2Fonly-logo.svg&widths=auto&widths=auto',
   editUrl: 'pages/guides/deploying-gridsome-with-zeit-now.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Gridsome](https://gridsome.org/) is an open source Vue.js site generator which gives developers the power to build sites that are fast by default.
@@ -47,7 +47,7 @@ You can deploy your Gridsome site with **a single command**:
   Deploying the site with the <InlineCode>now</InlineCode> command.
 </Caption>
 
-If you want to deploy your Gridsome project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Gridsome project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-hugo-with-now.mdx
+++ b/pages/guides/deploying-hugo-with-now.mdx
@@ -13,7 +13,7 @@ export const meta = {
   authors: ['unicodeveloper'],
   url: '/guides/deploying-hugo-with-now',
   editUrl: 'pages/guides/deploying-hugo-with-now.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Hugo](https://gohugo.io) is a very popular framework for creating static websites. It's fast and flexible.
@@ -114,7 +114,7 @@ With Now installed, you can deploy from your terminal with **a single command**:
   Deploying the app with the <InlineCode>now</InlineCode> command.
 </Caption>
 
-If you want to deploy your Hugo project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Hugo project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-nextjs-nodejs-and-faunadb-with-zeit-now.mdx
+++ b/pages/guides/deploying-nextjs-nodejs-and-faunadb-with-zeit-now.mdx
@@ -19,7 +19,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20a%20FaunaDB-Powered%20Next.js%20app**%20%3Cbr%2F%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=70px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fzeit-black-triangle.svg&images=https%3A%2F%2Fseeklogo.com%2Fimages%2FN%2Fnext-js-logo-7929BCD36F-seeklogo.com.png&images=https%3A%2F%2Fres-3.cloudinary.com%2Fcrunchbase-production%2Fimage%2Fupload%2Fc_lpad%2Ch_256%2Cw_256%2Cf_auto%2Cq_auto%3Aeco%2Fywnzi0pt0uw9klatmadc',
   editUrl: 'pages/guides/deploying-nextjs-nodejs-and-faunadb-with-zeit-now.mdx',
-  lastEdited: '2019-09-22T20:35:35.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [FaunaDB](https://fauna.com/) is a serverless cloud database that gives you low-latency access to your app data around the world.
@@ -299,7 +299,7 @@ You can now deploy the project with **a single command**:
 
 You will be given a deployment URL, with which you can access the contents of the FaunaDB database at the `/api` endpoint.
 
-To deploy your Next.js, Node.js, and FaunaDB project from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+To deploy your Next.js, Node.js, and FaunaDB project from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-nextjs-with-now.mdx
+++ b/pages/guides/deploying-nextjs-with-now.mdx
@@ -14,7 +14,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20Serverless%20Next.js**%20with%20Now.png?theme=light&md=1&fontSize=83px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg&heights=250&heights=350',
   editUrl: 'pages/guides/deploying-nextjs-with-now.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 Next.js is a framework, created by [ZEIT](https://zeit.co), for creating production-ready and lightning fast React apps with a lot of handy features built-in.
@@ -48,7 +48,7 @@ If you have not yet installed Now, you can do so by [installing Now CLI](/downlo
 <Snippet dark text="now" />
 <Caption>Deploying your project with the <InlineCode>now</InlineCode> command.</Caption>
 
-If you want to deploy your Next.js project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Next.js project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-preact-with-zeit-now.mdx
+++ b/pages/guides/deploying-preact-with-zeit-now.mdx
@@ -14,7 +14,7 @@ export const meta = {
   editUrl: 'pages/guides/deploying-preact-with-zeit-now.mdx',
   image:
     'https://og-image.now.sh/**Deploy%20a%20Preact%20App**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fwww.stickpng.com%2Fassets%2Fimages%2F584815e7cef1014c0b5e4978.png',
-  lastEdited: '2019-09-30T09:35:44.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Preact](https://preactjs.com/) is a fast 3kB alternative to React with the same modern API.
@@ -53,7 +53,7 @@ You can now deploy your Preact app with **a single command**:
   Deploying the app with the <InlineCode>now</InlineCode> command.
 </Caption>
 
-If you want to deploy your Preact project from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Preact project from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-pusher-channels-with-zeit-now.mdx
+++ b/pages/guides/deploying-pusher-channels-with-zeit-now.mdx
@@ -15,7 +15,7 @@ export const meta = {
   image:
     'https://og-image.now.sh/**Deploy%20Pusher%20Channels%20Apps**%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=96px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fpusher-icon.now-examples.now.sh&widths=250&widths=300&heights=250&heights=250',
   editUrl: 'pages/guides/deploying-pusher-channels-with-zeit-now.mdx',
-  lastEdited: '2019-09-17T08:46:12.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Pusher Channels](https://pusher.com/channels) is a service that makes it easy to add real-time data and functionality to web and mobile apps by using [WebSockets](https://en.wikipedia.org/wiki/WebSocket).
@@ -239,7 +239,7 @@ If you have not yet installed Now, you can do so by installing [Now CLI](/downlo
 <Snippet dark text="now" />
 <Caption>Deploying your project with the <InlineCode>now</InlineCode> command.</Caption>
 
-If you want to deploy your Channels project when you push to a Git repository, you can use either [Now for GitHub](/github) or [Now for GitLab](/gitlab) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Channels project when you push to a Git repository, you can use either [Now for GitHub](/github) or [Now for GitLab](/gitlab) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 You can find a full code example of an app made with this guide in [the ZEIT Now examples repository](https://github.com/zeit/now-examples/tree/master/vanilla-pusher-functions) on GitHub, along with the [live example](https://pusher-whiteboard.now-examples.now.sh/) deployed with ZEIT Now.
 

--- a/pages/guides/deploying-react-with-now-cra.mdx
+++ b/pages/guides/deploying-react-with-now-cra.mdx
@@ -12,7 +12,7 @@ export const meta = {
   authors: ['timothy', 'grovesjoseph'],
   url: '/guides/deploying-react-with-now-cra',
   editUrl: 'pages/guides/deploying-react-with-now-cra.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [React](https://reactjs.org/) is a popular open-source JavaScript framework, maintained by Facebook, for easily creating interactive [single-page apps](https://en.wikipedia.org/wiki/Single-page_application) (SPAs).
@@ -44,7 +44,7 @@ If you have not yet installed Now, you can do so by [installing Now CLI](/downlo
 
 With Now, you can deploy your app to [different environments](/docs/v2/custom-domains#deploying-with-your-domain), depending on what stage your app is at; either staging or production.
 
-To deploy to a unique alias, use the following [Now CLI](/download) command from your terminal:
+To deploy your React project, use the following [Now CLI](/download) command from your terminal:
 
 <Snippet dark text="now" />
 
@@ -52,7 +52,7 @@ To deploy to a unique alias, use the following [Now CLI](/download) command from
   Deploying the app with the <InlineCode>now</InlineCode> command.
 </Caption>
 
-If you want to deploy your React project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your React project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-statickit-with-zeit-now.mdx
+++ b/pages/guides/deploying-statickit-with-zeit-now.mdx
@@ -14,7 +14,7 @@ export const meta = {
   editUrl: 'pages/guides/deploying-statickit-with-zeit-now.mdx',
   image:
     'https://og-image.now.sh/**Deploy%20a%20StaticKit%20Project**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iNDYwcHgiIGhlaWdodD0iNDYwcHgiIHZpZXdCb3g9IjAgMCA0NjAgNDYwIiB2%250D%250AZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxp%250D%250Abms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPGcgc3Ryb2tlPSJub25lIiBz%250D%250AdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiIGZpbGwtcnVsZT0iZXZlbm9kZCI%2BCiAgICAgICAg%250D%250APGcgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoMTAwLjAwMDAwMCwgMTAwLjAwMDAwMCkiIGZpbGw9IiMw%250D%250AMDAwMDAiIGZpbGwtcnVsZT0ibm9uemVybyI%2BCiAgICAgICAgICAgIDxwYXRoIGQ9Ik0wLDAgTDI2%250D%250AMCwwIEwyNjAsNzYuNzgxMjUgTDI2MCwyNjAgTDAsMjYwIEwwLDAgWiBNMzAsMzAgTDMwLDIzMCBM%250D%250AMjMwLDIzMCBMMjMwLDMwIEwzMCwzMCBaIj48L3BhdGg%2BCiAgICAgICAgICAgIDxwb2x5Z29uIHRy%250D%250AYW5zZm9ybT0idHJhbnNsYXRlKDEzMC4wMDAwMDAsIDEzMC4wMDAwMDApIHJvdGF0ZSgtNDUuMDAw%250D%250AMDAwKSB0cmFuc2xhdGUoLTEzMC4wMDAwMDAsIC0xMzAuMDAwMDAwKSAiIHBvaW50cz0iNzAgMTQ1%250D%250AIDE5MCAxNDUgMTkwIDExNSA3MCAxMTUiPjwvcG9seWdvbj4KICAgICAgICA8L2c%2BCiAgICA8L2c%2B%250D%250ACjwvc3ZnPgo%3D&heights=200&heights=300',
-  lastEdited: '2019-09-13T14:53:08.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [StaticKit](https://statickit.com/) is a collection of dynamic components for static sites, enabling developers to build dynamic interfaces with ease.
@@ -171,7 +171,7 @@ When your app has deployed, it will look like the example below:
   The StaticKit + Next.js landing page created with this guide.
 </Caption>
 
-If you want to deploy your StaticKit + Next.js app from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your StaticKit + Next.js app from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 For more information, you can find the [source code](https://github.com/levelhq/statickit-examples/tree/master/next-landing-page) for this example on GitHub along with the [live example](https://next-landing-page.now-examples.now.sh/).
 

--- a/pages/guides/deploying-storybook-with-zeit-now.mdx
+++ b/pages/guides/deploying-storybook-with-zeit-now.mdx
@@ -15,7 +15,7 @@ export const meta = {
   editUrl: 'pages/guides/deploying-storybook-with-zeit-now.mdx',
   image:
     'https://og-image.now.sh/**Deploy%20a%20Storybook%20Library**%20%3Cbr%3E%20with%20ZEIT%20Now.png?theme=light&md=1&fontSize=100px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnow-black.svg&images=https%3A%2F%2Fpbs.twimg.com%2Fprofile_images%2F1100804485616566273%2FsOct-Txm_400x400.png',
-  lastEdited: '2019-08-30T09:17:58.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 [Storybook](https://storybook.js.org/) is an open source tool for developing JavaScript UI components in isolation. [Svelte](https://svelte.dev/) is a component framework that allows you to write highly-efficient, imperative code, that surgically updates the DOM to maintain performance.
@@ -72,7 +72,7 @@ You can now deploy your Storybook component library with **a single command**:
   Deploying the app with the <InlineCode>now</InlineCode> command.
 </Caption>
 
-If you want to deploy your Storybook component library from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your Storybook component library from a Git repository, you can use either [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/deploying-vuepress-to-now.mdx
+++ b/pages/guides/deploying-vuepress-to-now.mdx
@@ -11,7 +11,7 @@ export const meta = {
   authors: ['unicodeveloper'],
   url: '/guides/deploying-vuepress-to-now',
   editUrl: 'pages/guides/deploying-vuepress-to-now.mdx',
-  lastEdited: '2019-09-30T18:53:49.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 VuePress is a vue-powered static generator. It is used for generating static sites with a focus on writing.
@@ -108,7 +108,7 @@ You can deploy your VuePress app with **a single command**:
 
 When your app is deployed, you will receive a deployment URL like the following: <https://vuepress-nv3m85eee.now.sh/>
 
-If you want to deploy your VuePress project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and aliased on push to master.
+If you want to deploy your VuePress project when you push to a Git repository, you can use either [Now for GitHub](/docs/v2/integrations/now-for-github/) or [Now for GitLab](/docs/v2/integrations/now-for-gitlab/) to have your project automatically deployed on every push, and the [production domain](https://zeit.co/docs/v2/custom-domains/#adding-a-domain) updated on push to master.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/getting-started-with-now-for-gitlab.mdx
+++ b/pages/guides/getting-started-with-now-for-gitlab.mdx
@@ -7,15 +7,15 @@ import { GenericLink } from '~/components/text/link'
 export const meta = {
   title: 'Automatic Deployments with Now for GitLab',
   description:
-    'Setup ZEIT Now for GitLab and get automatic deployments and aliasing for each push.',
+    'Setup ZEIT Now for GitLab and get automatic deployments and staging domains for each push.',
   published: '2019-04-01T09:03:14.819Z',
   authors: ['arunoda', 'timothy'],
   url: '/guides/getting-started-with-now-for-gitlab',
   editUrl: 'pages/guides/getting-started-with-now-for-gitlab.mdx',
-  lastEdited: '2019-08-23T14:21:42.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
-The [Now for GitLab integration](/docs/v2/integrations/now-for-gitlab) provides you with automatic deployments for each push to a project, automatic aliases for pushes to the default branch, and instant rollbacks for reverts.
+The [Now for GitLab integration](/docs/v2/integrations/now-for-gitlab) provides you with automatic deployments for each push to a project, automatic staging domains for pushes to the default branch, and instant rollbacks for reverts.
 
 This guide will walk you through how to set up the Now for GitLab integration for your projects.
 
@@ -43,7 +43,7 @@ Push this file to your GitLab project so you have one file inside of it.
 
 ## Step 2: Connect Now to Your GitLab User and Project
 
-For Now to make automatic deployments and aliases, it needs access to your GitLab account and its associated projects.
+For Now to make automatic deployments and staging domains, it needs access to your GitLab account and its associated projects.
 
 Connect your GitLab account through your [account settings](/account).
 
@@ -65,7 +65,7 @@ With a project linked, no further setup is required on ZEIT.
 
 ## Step 3: Using Now for GitLab
 
-With configuration done, all future commits from your linked projects will have [automatic deployments for each push](#deployments-for-each-push), [merge requests](#deployments-and-staging-aliases-for-merge-requests), and [automatic aliasing to production](#deploying-to-production).
+With configuration done, all future commits from your linked projects will have [automatic deployments for each push](#deployments-for-each-push), [merge requests](#deployments-and-staging-domains-for-merge-requests), and [automatic updates for production domains](#deploying-to-production).
 
 ### Deployments For Each Push
 
@@ -93,7 +93,7 @@ Clicking the [commit](https://gitlab.com/now-examples/hello-world/commit/9fade7c
 
 Each commit will result in a unique URL just like the above.
 
-### Deployments and Staging Aliases for Merge Requests
+### Deployments and Staging Domains for Merge Requests
 
 [Merge requests](https://docs.gitlab.com/ee/user/project/merge_requests/) are a way to submit changes to a project without pushing directly to the default branch. This comes in handy when you're working on a feature that is either in progress or needs a review before being launched into production.
 
@@ -119,7 +119,7 @@ After you commit and create the merge request, you will get a [new view](https:/
 
 The pipeline information shows the status as Now builds your app. In this case, it has successfully built. It will show a different icon when Now is building the app.
 
-Below the pipeline message, a comment will present a [staging alias](/docs/v2/custom-domains#deploying-with-your-domain) that updates each time the merge request is pushed to, so you can share this link with others without having to worry about sharing the latest update.
+Below the pipeline message, a comment will present a [staging domain](/docs/v2/custom-domains#deploying-with-your-domain) that updates each time the merge request is pushed to, so you can share this link with others without having to worry about sharing the latest update.
 
 <Image
   src={`${process.env.ASSETS}/guides/getting-started-with-now-for-gitlab/merge-request-alias.png`}
@@ -127,19 +127,19 @@ Below the pipeline message, a comment will present a [staging alias](/docs/v2/cu
   height={1392/2.5}
   oversize
 />
-<Caption style={{marginTop: '-40px'}}>A staging alias created from a merge request.</Caption>
+<Caption style={{marginTop: '-40px'}}>A staging domain created from a merge request.</Caption>
 
-You can test this by creating another commit for the merge request and accessing the staging alias. You will notice that, once the commit is deployed, the staging alias will have been updated with the changes.
+You can test this by creating another commit for the merge request and accessing the staging domain. You will notice that, once the commit is deployed, the staging domain will have been updated with the changes.
 
 ## Deploying to Production
 
-Pushing or merging to the [default branch](https://docs.gitlab.com/ee/user/project/repository/branches/#default-branch) will result in a deployment, like any other branch or push. However, if you have an alias set in the **Domains** section of your project dashboard, these deployments will be automatically aliased to your configured destination.
+Pushing or merging to the [default branch](https://docs.gitlab.com/ee/user/project/repository/branches/#default-branch) will result in a deployment, like any other branch or push. However, if you have a production domain set in the **Domains** section of your project dashboard, these deployments will be automatically available at your configured destination.
 
 <Note hint>
-  You can read more about adding aliases, both staging and production, to
+  You can read more about adding domains, both staging and production, to
   deployments in the{' '}
   <GenericLink href="/docs/v2/custom-domains#deploying-with-your-domain">
-    aliasing a deployment documentation
+    custom domains documentation
   </GenericLink>
   .
 </Note>
@@ -152,13 +152,13 @@ When you push this change to the default branch, this and all subsequent commits
   height={1392/2.5}
   oversize
 />
-<Caption style={{marginTop: '-40px'}}>A staging alias created from a merge request.</Caption>
+<Caption style={{marginTop: '-40px'}}>A staging domain created from a merge request.</Caption>
 
 ## In Conclusion
 
 Through this guide, you should now have a bulletproof deployment pipeline for all of your GitLab projects, using [Now for GitLab](/docs/v2/integrations/now-for-gitlab).
 
-With every push, an automatic deployment. With every merge request, a unique staging alias. And with every update to the default branch, your changes are aliased to production.
+With every push, an automatic deployment. With every merge request, a unique staging domain. And with every update to the default branch, your changes are updated for the production domain.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/redirect-from-www.mdx
+++ b/pages/guides/redirect-from-www.mdx
@@ -12,14 +12,14 @@ export const meta = {
   authors: ['timothy'],
   url: '/guides/redirect-from-www',
   editUrl: 'pages/guides/redirect-from-www.mdx',
-  lastEdited: '2019-09-13T14:50:12.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 Redirecting is useful for a variety of situations, including redirecting a visitor that goes to your domain with `www.` prefixing the URL to [your domain](/docs/v2/custom-domains) without that prefix.
 
 Now provides configuration to help make redirecting easier through [the `routes` property](/docs/v2/advanced/configuration#routes) within a [`now.json` file](/docs/v2/advanced/configuration).
 
-To redirect visitors from the `www.` subdomain to your naked domain, you can create a `now.json` file with the aforementioned configuration property in a new folder to deploy as a separate deployment to the one that is [aliased](/docs/v2/custom-domains#deploying-with-your-domain) to your naked domain.
+To redirect visitors from the `www.` subdomain to your naked domain, you can create a `now.json` file with the aforementioned configuration property in a new folder to deploy as a separate deployment to the one that is being used as a [production domain](/docs/v2/custom-domains#deploying-with-your-domain).
 
 <Note type="warning">
   This guide only applies for custom domains and will not work with the{' '}
@@ -58,7 +58,7 @@ Next, create a `now.json` file in that directory with the following content:
 The above configuration uses a few properties to configure the deployment:
 
 - `version`: The [version property](/docs/v2/advanced/configuration#version) specifies the Now platform version to use, in this case, we are using the [latest version 2.0](/docs/v2/platform/overview/#versioning).
-- `alias`: The [alias property](/docs/v2/advanced/configuration#alias) defines a single or set of aliases to assign the deployment to, using [the production aliasing environment](/docs/v2/custom-domains#deploying-with-your-domain).
+- `alias`: The [alias property](/docs/v2/advanced/configuration#alias) defines a single or set of domains to assign the deployment to, using [the production domain](/docs/v2/custom-domains#deploying-with-your-domain).
 - `routes`: The [routes property](/docs/v2/advanced/configuration#routes) allows Now to route your deployment as you intend it and configure it to be routed using a source and destination, or by way of a source, status, and headers.
 
 With this configuration, you are allowing Now to understand how to route the visitor with the `routes` property from the source, comprising of a PCRE regex capture group `/(.*)`, a [HTTP status of 301](https://en.wikipedia.org/wiki/HTTP_301) (Moved Permanently), and a `Location` header that directs to the naked domain with the captured path appended via `$1`.
@@ -73,11 +73,11 @@ Using Now CLI, you can deploy the project from your terminal using the following
 
 <Snippet dark text="now" />
 
-To push your deployment into production, deploy and alias it with the [production aliasing target](/docs/v2/custom-domains#deploying-with-your-domain):
+To push your deployment into production using a [production domain](/docs/v2/custom-domains#deploying-with-your-domain):
 
 <Snippet dark text="now --prod" />
 
-Now, when visiting either the production alias (www.your-domain.com), a [staging alias](/docs/v2/custom-domains#deploying-with-your-domain), or a [deployment URL](/docs/v2/advanced/concepts/urls/), the visitor will get redirected to the location set as defined by the [`routes` property](/docs/v2/deployments/routes/) in the `now.json` file.
+Now, when visiting either the production domain (www.your-domain.com), a [staging domain](/docs/v2/custom-domains#deploying-with-your-domain), or a [deployment URL](/docs/v2/advanced/concepts/urls/), the visitor will get redirected to the location set as defined by the [`routes` property](/docs/v2/deployments/routes/) in the `now.json` file.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/setup-godaddy-domain-now.mdx
+++ b/pages/guides/setup-godaddy-domain-now.mdx
@@ -8,17 +8,17 @@ import { GenericLink } from '~/components/text/link'
 export const meta = {
   title: 'Setup a GoDaddy Domain with ZEIT Now',
   description:
-    'Use your GoDaddy registered domain as an alias for your ZEIT Now deployments.',
+    'Use your GoDaddy registered domain for your ZEIT Now deployments.',
   published: '2019-01-23T17:00:00.860Z',
   authors: ['timothy'],
   url: '/guides/setup-godaddy-domain-now',
   editUrl: 'pages/guides/setup-godaddy-domain-now.mdx',
-  lastEdited: '2019-08-23T14:21:42.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
-With Now, you can [assign a domain name](/docs/v2/custom-domains#deploying-with-your-domain) to any of your [deployments](/docs/v2/deployments/basics/) by aliasing. If you have a domain registered on another service, such as GoDaddy, you must first [point your domain to Now](/guides/zero-downtime-domain-migration/) in order to alias your deployments.
+With ZEIT Now, you can [assign a domain name](/docs/v2/custom-domains#deploying-with-your-domain) to any of your [deployments](/docs/v2/deployments/basics/) in. If you have a domain registered on another service, such as GoDaddy, you must first [point your domain to Now](/guides/zero-downtime-domain-migration/) in order to use it for your deployments.
 
-This guide will cover **how to point your GoDaddy registered domain towards Now** in order to alias your deployments to that domain.
+This guide will cover **how to point your GoDaddy registered domain towards Now** in order to use your domain for your deployments.
 
 ## Step 1: Adding and Verifying Your Domain
 
@@ -44,7 +44,7 @@ You will have two options. Either to verify your domain [with nameservers](#veri
 
 This is the fastest method of getting started with your domain on Now. When using nameservers, you are both verifying and pointing to Now all at once.
 
-When using this method, however, if the domain was previously pointing to another host and if you have not yet configured Now for your domain, e.g. generating SSL certificates and aliasing; when it does point to Now, it will invoke downtime until the configuration is done. To avoid this, use [the `TXT` verification method](#verifying-with-a-txt-record).
+When using this method, however, if the domain was previously pointing to another host and if you have not yet configured Now for your domain, e.g. generating SSL certificates; when it does point to Now, it will invoke downtime until the configuration is done. To avoid this, use [the `TXT` verification method](#verifying-with-a-txt-record).
 
 If you want to verify with nameservers, you must use the intended set of nameservers given to you when you [added the domain with Now CLI](/docs/v2/custom-domains). If you need to be reminded of these nameservers, you can use the [following command](/docs/v2/custom-domains):
 
@@ -100,7 +100,7 @@ Once you have added the TXT record, your domain can be verified. ZEIT will perio
 
 ## Step 2: Configuring Your Domain on Now
 
-If you have used either verification method, the next step may be to configure your domain with DNS records and to alias a deployment to your domain.
+If you have used either verification method, the next step may be to configure your domain with DNS records and to use it for a deployment.
 
 ### Adding DNS Records
 
@@ -115,30 +115,18 @@ For example, adding a set of Gmail MX records with the `now dns add` command:
 
 [Read more about `now dns` to learn about the format of the command](/docs/v2/advanced/domains/dns/).
 
-### Aliasing a Deployment
+### Adding a Domain to Deployments
 
-ZEIT Now is dedicated to making deployment easy. If you have not yet deployed an app, take a look at the [Deployment Basics](/docs/v2/deployments/basics) documentation or at some other [guides](/guides) or [examples](/examples) to get started. The aliasing process will also generate a free SSL certificate for your domain.
+ZEIT Now is dedicated to making deployment easy. If you have not yet deployed an app, take a look at the [Deployment Basics](/docs/v2/deployments/basics) documentation or at some other [guides](/guides) or [examples](/examples) to get started.
 
-When you are ready to deploy and alias, using the [`alias`](/docs/v2/advanced/configuration#alias) property containing your domain, within your [`now.json`](/docs/v2/advanced/configuration) file.
+Adding your production domain to a project can be done from the [ZEIT Dashboard](/dashboard) by selecting the project's **Domains** tab and entering it there, you can find more information on this in the [custom domains documentation](https://zeit.co/docs/v2/custom-domains/#adding-a-domain).
 
-```json
-{
-  "alias": "www.yourdomain.com"
-}
-```
-
-<Caption>
-  Adding an{' '}
-  <GenericLink href="/docs/v2/advanced/configuration/#alias">alias</GenericLink>{' '}
-  to your project's <InlineCode>now.json</InlineCode> file.
-</Caption>
-
-You can deploy and set up an alias to your domain with one command:
+You can then deploy to your production domain with **a single command**:
 
 <Snippet dark text="now --prod" />
-<Caption>Deploying a project to a production alias.</Caption>
+<Caption>Deploying a project to a production domain.</Caption>
 
-We highly recommend using either the [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) apps coupled with the same [`alias` configuration option](/docs/v2/advanced/configuration/#alias) which will allow your app to be deployed on push to your GitHub repository and aliased automatically when merged to the default branch.
+We highly recommend using either the [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) apps which will allow your app to be deployed to your production on push to your GitHub repository or GitLab project.
 
 ## Step 3: Pointing to Now
 
@@ -156,7 +144,7 @@ To set your nameservers, on the DNS management page as you added the TXT record,
 />
 <Caption style={{marginTop: '-48px'}}>Changing nameservers with GoDaddy's DNS management settings.</Caption>
 
-Once GoDaddy propagates the changes to the domain with the updated nameservers, your domain will then point to the [app you deployed](#aliasing-a-deployment) before.
+Once GoDaddy propagates the changes to the domain with the updated nameservers, your domain will then point to the [app you deployed](#adding-a-domain-to-deployments) before.
 
 That's all. Your domain is successfully migrated to using ZEIT DNS and pointing to your Now deployed app.
 

--- a/pages/guides/setup-namecheap-domain-now.mdx
+++ b/pages/guides/setup-namecheap-domain-now.mdx
@@ -8,15 +8,15 @@ import { GenericLink } from '~/components/text/link'
 export const meta = {
   title: 'Setup a Namecheap Domain with ZEIT Now',
   description:
-    'Use your Namecheap registered domain as an alias for your ZEIT Now deployments.',
+    'Use your Namecheap registered domain for your ZEIT Now deployments.',
   published: '2019-02-15T17:00:00.860Z',
   authors: ['unicodeveloper'],
   url: '/guides/setup-namecheap-domain-now',
   editUrl: 'pages/guides/setup-namecheap-domain-now.mdx',
-  lastEdited: '2019-08-23T14:21:42.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
-In this guide, we will cover how to use your Namecheap registered domain as an alias for your ZEIT Now deployments.
+In this guide, we will cover how to use your Namecheap registered domain as a production domain for your ZEIT Now deployments.
 
 ## Step 1: Adding and Verifying Your Domain
 
@@ -107,7 +107,7 @@ Your domain will be verified after adding the TXT record. Once ZEIT verifies you
 
 ## Step 2: Configuring your Domain on Now
 
-Once your domain has been verified on Now, you can configure your domain with DNS records and alias a deployment to it.
+Once your domain has been verified on Now, you can configure your domain with DNS records and add it as a production domain for deployments.
 
 ### Adding DNS Records
 
@@ -121,32 +121,20 @@ now dns add <domain> @ MX ALT3.ASPMX.L.GOOGLE.COM 10
 now dns add <domain> @ MX ALT4.ASPMX.L.GOOGLE.COM 10
 ```
 
-Learn more about using the [`now dns`](https://zeit.co/docs/v2/advanced/domains/dns/) command.
+Learn more about using the [`now dns`](/docs/v2/advanced/domains/dns/) command.
 
-### Deploying and Aliasing
+### Adding a Domain to Deployments
 
-ZEIT Now is dedicated to making deployment easy. If you have not yet deployed an app, take a look at the [Deployment Basics](/docs/v2/deployments/basics) documentation or at some other [guides](/guides) or [examples](/examples) to get started. The aliasing process will also generate a free SSL certificate for your domain.
+ZEIT Now is dedicated to making deployment easy. If you have not yet deployed an app, take a look at the [Deployment Basics](/docs/v2/deployments/basics) documentation or at some other [guides](/guides) or [examples](/examples) to get started.
 
-When you are ready to deploy and alias, using the [`alias`](/docs/v2/advanced/configuration#alias) property containing your domain, within your [`now.json`](/docs/v2/advanced/configuration).
+Adding your production domain to a project can be done from the [ZEIT Dashboard](/dashboard) by selecting the project's **Domains** tab and entering it there, you can find more information on this in the [custom domains documentation](/docs/v2/custom-domains/#adding-a-domain).
 
-```json
-{
-  "alias": "www.yourdomain.com"
-}
-```
-
-<Caption>
-  Adding an{' '}
-  <GenericLink href="/docs/v2/advanced/configuration/#alias">alias</GenericLink>{' '}
-  to your project's <InlineCode>now.json</InlineCode> file.
-</Caption>
-
-You can deploy and set up an alias to your domain with one command:
+You can then deploy to your production domain with **a single command**:
 
 <Snippet dark text="now --prod" />
-<Caption>Deploying a project to a production alias.</Caption>
+<Caption>Deploying a project to a production domain.</Caption>
 
-We highly recommend using either the [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) apps coupled with the same [`alias` configuration option](/docs/v2/advanced/configuration/#alias) which will allow your app to be deployed on push to your GitHub repository and aliased automatically when merged to the default branch.
+We highly recommend using either the [Now for GitHub](/docs/v2/advanced/now-for-github/) or [Now for GitLab](/docs/v2/advanced/now-for-gitlab/) apps which will allow your app to be deployed to your production on push to your GitHub repository or GitLab project.
 
 ## Step 3: Pointing to Now
 
@@ -154,7 +142,7 @@ If you already verified your domain with nameservers, then this step is done.
 
 The final step of migrating your domain to Now is to point your domain to ZEIT DNS with the intended nameservers set. Using `now domains inspect <domain>`, you can always find the intended nameservers to use with your domain.
 
-Once Namecheap's propagation of the updated nameservers is complete, your domain will automatically point to the [app you deployed](https://zeit.co/guides/setup-godaddy-domain-now/#aliasing-a-deployment) before.
+Once Namecheap's propagation of the updated nameservers is complete, your domain will automatically point to the [app you deployed](#adding-a-domain-to-deployments) before.
 
 export default ({ children }) => <Guide meta={meta}>{children}</Guide>
 

--- a/pages/guides/zero-downtime-domain-migration.mdx
+++ b/pages/guides/zero-downtime-domain-migration.mdx
@@ -14,7 +14,7 @@ export const meta = {
   authors: ['msweeneydev'],
   url: '/guides/zero-downtime-domain-migration',
   editUrl: 'pages/guides/zero-downtime-domain-migration.mdx',
-  lastEdited: '2019-08-27T14:52:10.000Z'
+  lastEdited: '2019-10-02T14:07:07.000Z'
 }
 
 When migrating to another set of nameservers, there can often be downtime incurred. In this guide we will walk you through adding your domain to ZEIT and setting it up before migrating the nameservers, ensuring no downtime at any point.
@@ -123,7 +123,7 @@ Select a project from your dashboard and click the **Domains** tab. Add your cus
 
 If the domain is **registered to your account and available for use** it will be indicated below the input box and you can continue. Otherwise, if the domain is **not registered to your account**, it will automatically be added and we will attempt to verify it for you.
 
-When the domain is verified and you're ready to deploy your project to production, you can use the production target with Now CLI in your terminal:
+When the domain is verified, you can deploy your project to production with Now CLI:
 
 <Snippet dark text="now --prod" />
 <Caption>Deploying a project to production with Now CLI.</Caption>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -566,7 +566,7 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-a-mongodb-powered-api-with-node-and-now/</loc>
-    <lastmod>2019-08-23T14:21:42.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -576,27 +576,27 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-apolloserver-to-now/</loc>
-    <lastmod>2019-09-17T08:46:12.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-charge-with-now/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-gatsby-with-now/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-gridsome-with-zeit-now/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-hugo-with-now/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -626,12 +626,12 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-nextjs-nodejs-and-faunadb-with-zeit-now/</loc>
-    <lastmod>2019-09-22T20:35:35.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-nextjs-with-now/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -641,12 +641,12 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-preact-with-zeit-now/</loc>
-    <lastmod>2019-09-30T09:35:44.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-pusher-channels-with-zeit-now/</loc>
-    <lastmod>2019-09-17T08:46:12.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -656,7 +656,7 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-react-with-now-cra/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -666,12 +666,12 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-statickit-with-zeit-now/</loc>
-    <lastmod>2019-09-13T14:53:08.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-storybook-with-zeit-now/</loc>
-    <lastmod>2019-08-30T09:17:58.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -681,12 +681,12 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/deploying-vuepress-to-now/</loc>
-    <lastmod>2019-09-30T18:53:49.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/getting-started-with-now-for-gitlab/</loc>
-    <lastmod>2019-08-23T14:21:42.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -714,17 +714,17 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/redirect-from-www/</loc>
-    <lastmod>2019-09-13T14:50:12.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/setup-godaddy-domain-now/</loc>
-    <lastmod>2019-08-23T14:21:42.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
     <loc>https://zeit.co/guides/setup-namecheap-domain-now/</loc>
-    <lastmod>2019-08-23T14:21:42.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
   <url>
@@ -743,7 +743,7 @@
   </url>
   <url>
     <loc>https://zeit.co/guides/zero-downtime-domain-migration/</loc>
-    <lastmod>2019-08-27T14:52:10.000Z</lastmod>
+    <lastmod>2019-10-02T14:07:07.000Z</lastmod>
     <changefreq>hourly</changefreq>
   </url>
 </urlset>


### PR DESCRIPTION
This PR updates the language used in guides to focus on domains, staging domains and production domains rather than targets or aliases.