### PR TITLE
Fix `keyup` event listener in `Layout` component.

### DIFF
--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -79,7 +79,7 @@ class Layout extends React.Component {
 
   componentDidMount() {
     document.addEventListener('keydown', this.onKeyDown.bind(this), false)
-    document.addEventListener('keyUp', this.onKeyUp.bind(this), false)
+    document.addEventListener('keyup', this.onKeyUp.bind(this), false)
     window.addEventListener('scroll', this.onScroll.bind(this))
   }
 

--- a/components/layout/layout.js
+++ b/components/layout/layout.js
@@ -64,7 +64,6 @@ class Layout extends React.Component {
     if (event.which === 18) {
       this.altKeyDown = false
     }
-    this.altKeyDown = false
   }
 
   onScroll() {


### PR DESCRIPTION
This closes #1358.

This fixes a typo on the `keyup` event listener in the `Layout`
component. Previously, this component was listening for `keyUp`, but the
event should be [`keyup`](https://developer.mozilla.org/en-US/docs/Web/API/Document/keyup_event).

This fixes an issue where ZenMode could be enabled by pressing `alt` and
then `z` separately instead of together
(https://github.com/zeit/docs/issues/1358). Because `onKeyUp` was not
being triggered, we never updated the state to indicate `alt` was no
longer being pressed down.

## Before

This shows that you can keydown `alt` then keydown `z` and trigger ZenMode:

![alt-then-z-work](https://user-images.githubusercontent.com/691365/66257277-deaaeb80-e764-11e9-8635-bc3a1b10c0db.gif)

## After

This shows that ZenMode does not trigger for `alt` then `z`, but does when you hold `alt` and `z`:

![alt_z_fix](https://user-images.githubusercontent.com/691365/66306376-788ea780-e8cf-11e9-8e74-1d2165b4c868.gif)


## Notes
- Running `yarn test` resulted in `150 problems (148 errors, 2 warnings)`. None of these errors seemed to be in the `Layout` component, so I am guessing they are existing issues. 
- ~I noticed that holding `alt` and hitting `z` multiple times does not seem to continue to toggling ZenMode, but you let go and `alt`+`z` again. Is that okay?~  Fixed in 90212a2a909225060f83a09155d7a14bce67147f.