### PR TITLE
Update headers.mdx

### DIFF
--- a/pages/docs/v2/network/headers.mdx
+++ b/pages/docs/v2/network/headers.mdx
@@ -19,7 +19,7 @@ The following headers are sent to each ZEIT Now deployment and can be used to pr
 
 This header represents the domain name as it was accessed by the client. If the deployment has been assigned to a staging or production domain and the client visits the domain URL, it contains the custom domain instead of the underlying deployment URL.
 
-### `now-id`
+### `x-now-id`
 
 A unique identifier for each request.
 


### PR DESCRIPTION
`req.headers["now-id"]` results in `undefined`, however `req.headers["x-now-id"]` is set.
I'm guessing this is a typo in the documentation.