### PR TITLE
Update platform API docs: Projects

### DIFF
--- a/components/references-mdx/api/v2/endpoints/projects.mdx
+++ b/components/references-mdx/api/v2/endpoints/projects.mdx
@@ -42,6 +42,15 @@ Create a new project with the `name` request parameter. If the project already e
 <Code lang="json">{`{
   "id":"QmQKrt94KYKF3sDysJq19N87uMmE8Wicbt2GirePy1dH8U",
   "name":"a-project-name",
+  "alias":[
+    {
+      "domain": "a-project-name-elegant-deer.now.sh",
+      "target": "PRODUCTION",
+      "createdAt": 1555413045188,
+      "configuredBy": "A",
+      "configuredChangedAt": 1555413045188
+    }
+  ],
   "accountId":"K4amb7K9dAt5R2vBJWF32bmY",
   "updatedAt":1555413045188,
   "createdAt":1555413045188
@@ -78,6 +87,15 @@ Create a project with the `name` request parameter if it does not already exist.
 <Code lang="json">{`{
   "id":"QmQKrt94KYKF3sDysJq19N87uMmE8Wicbt2GirePy1dH8U",
   "name":"a-project-name",
+  "alias":[
+    {
+      "domain": "a-project-name-elegant-deer.now.sh",
+      "target": "PRODUCTION",
+      "createdAt": 1555413045188,
+      "configuredBy": "A",
+      "configuredChangedAt": 1555413045188
+    }
+  ],
   "accountId":"K4amb7K9dAt5R2vBJWF32bmY",
   "updatedAt":1555413045188,
   "createdAt":1555413045188


### PR DESCRIPTION
Makes the updates described in this blog post:

https://zeit.co/blog/default-production-domain#api-changes

It mentions that there's a newer version of the API and it's opt-in, but I tested it with the `v1/projects` and it still created the default domain