### PR TITLE
Change directory the build should be output to

### DIFF
--- a/pages/guides/deploying-nuxtjs-with-zeit-now.mdx
+++ b/pages/guides/deploying-nuxtjs-with-zeit-now.mdx
@@ -49,7 +49,7 @@ Before deploying with ZEIT Now, provide Nuxt.js with instructions on which direc
 {
   ...
   "generate": {
-    "dir": "public"
+    "dir": "dist"
   }
 }
 ```

--- a/pages/guides/deploying-nuxtjs-with-zeit-now.mdx
+++ b/pages/guides/deploying-nuxtjs-with-zeit-now.mdx
@@ -43,22 +43,6 @@ With your Nuxt.js project initialized, move into the directory:
   directory.
 </Caption>
 
-Before deploying with ZEIT Now, provide Nuxt.js with instructions on which directory the build should be output to. Add the following to your `nuxt.config.js` file:
-
-```json
-{
-  ...
-  "generate": {
-    "dir": "dist"
-  }
-}
-```
-
-<Caption>
-  Adding an output directory to the <InlineCode>nuxt.config.js</InlineCode>{' '}
-  file.
-</Caption>
-
 Following that, change the build script in the `package.json` file to the following:
 
 ```json


### PR DESCRIPTION
This seems to have changed to 'dist' where it was 'public' before? I ran into errors and changing this value (as per the error message) got it working again.