### PR TITLE
Use NPX to utilize create-next-app

### DIFF
--- a/pages/guides/deploying-nextjs-with-now.mdx
+++ b/pages/guides/deploying-nextjs-with-now.mdx
@@ -27,7 +27,7 @@ In this guide, you will learn how to create and deploy a [Next.js](https://nextj
 
 The first step in setting up your new Next.js project is to generate it with [`create-next-app`](https://github.com/zeit/next.js#quick-start):
 
-<Snippet dark text="npm init next-app my-next-app && cd my-next-app" />
+<Snippet dark text="npx create-next-app my-next-app && cd my-next-app" />
 <Caption>
   Initializing a Next.js project with <InlineCode>create-next-app</InlineCode>{' '}
   and <Link href="https://www.npmjs.com/">npm</Link>, then moving into the project directory.


### PR DESCRIPTION
Currently the step 1 in the documentation simply creates a `package.json`, which I don't think was the intention.