### PR TITLE
Remove Now CLI from introduction

### DIFF
--- a/pages/docs/v2/introduction.mdx
+++ b/pages/docs/v2/introduction.mdx
@@ -13,7 +13,7 @@ export const meta = {
   description:
     'An introduction to the ZEIT Now platform and how to get started deploying any kind of application.',
   editUrl: 'pages/docs/v2/introduction.mdx',
-  lastEdited: '2020-01-24T11:19:54.000Z'
+  lastEdited: '2020-01-28T00:14:27.000Z'
 }
 
 ZEIT Now is a cloud platform for **static sites** and **Serverless Functions** that fits perfectly with your workflow. It enables developers to host **JAMstack** websites and web services that **deploy instantly**, **scale automatically**, and requires **no supervision**, all with **no configuration**.
@@ -45,47 +45,11 @@ Quickstarts let you get started quickly. The following quickstarts are paired wi
   ))}
 </Quickstarts>
 
-## Deploying a Project Locally
-
-If you like to do things manually, you can deploy with ZEIT Now through your terminal with any local project.
-
-To deploy with ZEIT Now through your terminal, you will need to install [Now CLI](/download), a frequently updated, and [open-source](https://github.com/zeit/now), command-line interface.
-
-You can get Now CLI from either npm or Yarn. Using npm, run the following command from your terminal:
-
-<Snippet
-  dark
-  text="npm i -g now"
-/>
-<Caption>Installing Now CLI with npm in the terminal.</Caption>
-
-To verify that you have installed Now CLI, try running `now help` from your terminal.
-
-With Now CLI installed, you can now login using the following command:
-
-<Snippet
-  dark
-  text="now login"
-/>
-<Caption>Login with Now CLI from the terminal.</Caption>
-
-Logged in, you can type the following command to deploy from your project's repository:
-
-<Snippet
-  dark
-  text="now"
-/>
-<Caption>Deploying with Now CLI from the terminal.</Caption>
-
-Once deployed, you will get a preview URL that is assigned on each deployment to share the latest changes under the same address.
-
-The preview URL will look like the following: <https://my-next-project.now-examples.now.sh/>
-
 ## Related
 
 For more information on what to do next, we recommend the following articles:
 
-<Card title="Git Integration" href="/docs/v2/git-integration">
+<Card title="Git Integrations" href="/docs/v2/git-integrations">
   Learn more about how ZEIT Now integrates with Git to make your workflow
   easier.
 </Card>


### PR DESCRIPTION
This pull request removes Now CLI from the introduction.