### PR TITLE
Add a note about installing now CLI

### DIFF
--- a/components/references-mdx/now-cli/introduction/introduction.mdx
+++ b/components/references-mdx/now-cli/introduction/introduction.mdx
@@ -16,6 +16,8 @@ export const meta = {
 
 [Now CLI](/download) provides a set of commands that allow you to deploy and manage your projects. This page contains a complete list of all Now CLI commands available, alongside their optional parameters for additional behavior.
 
+To download and install Now CLI, [follow the instructions here](/download).
+
 All commands and options are listed in the following categories:
 
 | Category              | Description                              |


### PR DESCRIPTION
- Added a clear link to installation instructions for the [Now CLI reference page](https://zeit.co/docs/now-cli).
- With all the changes we're making to make the Git workflow more prominent, it'll be more likely that the user will arrive this page without having `now` installed.
- Although you can click on one of the texts that says "Now CLI" to get to the installation page, it's not immediately clear. This PR makes it more explicit.
- I didn't add the instructions itself to this page because [`/download`](https://zeit.co/download) has a lot more information (including [what to do when things go wrong](https://user-images.githubusercontent.com/992008/74398726-6ec10780-4dcd-11ea-8216-783bda158896.png))
