### PR TITLE
Update Env Variables to include build object

### DIFF
--- a/pages/docs/v2/serverless-functions/env-and-secrets.mdx
+++ b/pages/docs/v2/serverless-functions/env-and-secrets.mdx
@@ -69,6 +69,21 @@ To provide your Serverless Functions with the environment variables you have def
   Functions with a defined environment variable.
 </Caption>
 
+When using an Environment Variables in an application that bakes in environment variables at build time like *Nuxt.js* , inlcuding a `build` object to the `now.json` file might be necessary inorder for Environment Variables to be available in certain files. An example of the `now.json` file is; 
+
+```json
+  "build": {
+		"env": {
+			"GRAPHQL_URL": "@graphql_url"
+		}
+	}
+```
+
+<Caption>
+  An example <InlineCode>now.json</InlineCode> file that includes a build object inorder to be accessible on at build time.
+</Caption>
+
+
 When providing environment variables to your application, the value should always be prefixed with `@`, followed by the name of the [Now Secret](#adding-secrets) or environment variable name if using an `.env` file [during local development](#during-local-development).
 
 To use the environment variable from inside the application you would need to reference it using the correct syntax for the language being used. For example, using Node.js, the syntax would be:

--- a/pages/docs/v2/serverless-functions/env-and-secrets.mdx
+++ b/pages/docs/v2/serverless-functions/env-and-secrets.mdx
@@ -74,7 +74,7 @@ When using an Environment Variables in an application that bakes in environment 
 ```json
   "build": {
 		"env": {
-			"GRAPHQL_URL": "@graphql_url"
+			"VARIABLE_NAME": "@variable-name"
 		}
 	}
 ```


### PR DESCRIPTION
I recently spent hours trying to figure out why env variables where not available to my nuxt.config.js file until i found this github issue https://github.com/nuxt/now-builder/issues/108. 

I think this should be added inorder to help others who might face similar issue.