### PR TITLE
Match header height with homepage

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,5 @@
 // UI Constants
-export const HEADER_HEIGHT = 80
+export const HEADER_HEIGHT = 64
 
 // API Endpoints
 export const API_USER = '/api/www/user'


### PR DESCRIPTION
Homepage header has changed from 80px to 64px, to keep consistency I've switched the `constant` accordingly.