### PR TITLE
fix docs confusing typo

### DIFF
--- a/pages/guides/deploying-next-and-storyblok-with-now.mdx
+++ b/pages/guides/deploying-next-and-storyblok-with-now.mdx
@@ -306,7 +306,7 @@ STORYBLOK_API_TOKEN=your-api-token
 
 Lastly, to make your API key available for [cloud deployment](/docs/v2/deployments/basics/), create a [Now Secret](/docs/v2/deployments/environment-variables-and-secrets#securing-environment-variables-using-secrets) with the command below:
 
-<Snippet dark text="now secrets add STORYBLOK_API_TOKEN your-space-id" />
+<Snippet dark text="now secrets add STORYBLOK_API_TOKEN your-api-token" />
 <Caption>
   Adding the <InlineCode>STORYBLOK_API_TOKEN</InlineCode> secret to your project using <Link href="/docs/v2/deployments/environment-variables-and-secrets#securing-environment-variables-using-secrets">Now Secrets</Link>.
 </Caption>


### PR DESCRIPTION
Changed 'your-space-id' to 'your-api-token'.