### PR TITLE
Update links to the old Next.js docs

### DIFF
--- a/pages/docs/v2/serverless-functions/introduction.mdx
+++ b/pages/docs/v2/serverless-functions/introduction.mdx
@@ -26,7 +26,7 @@ To create a Serverless Function, create a file in an `/api` directory from your 
   If you are using Next.js, use the <InlineCode>/pages/api</InlineCode>{' '}
   directory instead.
   <br />
-  <Link href="https://nextjs.org/docs#api-routes">
+  <Link href="https://nextjs.org/docs/api-routes/introduction">
     Read more about API functionality with Next.js
   </Link>
   .
@@ -56,7 +56,7 @@ To deploy Serverless Functions without any additional configuration, you can put
   If you are using Next.js, use the <InlineCode>/pages/api</InlineCode>{' '}
   directory instead.
   <br />
-  <Link href="https://nextjs.org/docs#api-routes">
+  <Link href="https://nextjs.org/docs/api-routes/introduction">
     Read more about API functionality with Next.js
   </Link>
   .

--- a/pages/guides/custom-next-js-server-to-routes.mdx
+++ b/pages/guides/custom-next-js-server-to-routes.mdx
@@ -48,9 +48,9 @@ server.get('/products/:name', (req, res) => {
 
 ### The New Routes Method
 
-With [ZEIT Now](https://zeit.co/now) and the serverless approach, each [Next.js page](https://nextjs.org/docs#routing) is a separate entry point, making the sole custom server entry point a thing of the past for the good of performance and stability. Fortunately, **ZEIT Now 2.0 offers a solution**, handling the configuration of routes for you.
+With [ZEIT Now](https://zeit.co/now) and the serverless approach, each [Next.js page](https://nextjs.org/docs/basic-features/pages) is a separate entry point, making the sole custom server entry point a thing of the past for the good of performance and stability. Fortunately, **ZEIT Now 2.0 offers a solution**, handling the configuration of routes for you.
 
-By making use of Next.js path segments with ZEIT Now, [dynamic routing](https://nextjs.org/docs#routing) is achieved through the file structure. No longer are custom servers or additional configuration required, **simplifying the process of building your app significantly**.
+By making use of Next.js path segments with ZEIT Now, [dynamic routing](https://nextjs.org/docs/routing/dynamic-routes) is achieved through the file structure. No longer are custom servers or additional configuration required, **simplifying the process of building your app significantly**.
 
 ## By Example
 

--- a/pages/guides/deploying-next-and-prismic-with-now.mdx
+++ b/pages/guides/deploying-next-and-prismic-with-now.mdx
@@ -198,7 +198,7 @@ export default Post
 
 ## Step 4: Build Client Side Navigation Links
 
-Now that the pages for your blog post documents are accessible, you can modify the index page so that the list of titles actually links to each of the posts. To do this, it's best to use the [`<Link>`](https://nextjs.org/docs#with-link) component, included with [Next.js](https://nextjs.org/), to provide client-side navigation without a page refresh.
+Now that the pages for your blog post documents are accessible, you can modify the index page so that the list of titles actually links to each of the posts. To do this, it's best to use the [`<Link>`](https://nextjs.org/docs/api-reference/next/link) component, included with [Next.js](https://nextjs.org/), to provide client-side navigation without a page refresh.
 
 The `<Link>` component requires **two main props for navigation**: `href`, which will be the path used to route to the page, and `as`, which will be the path as rendered in the browser. To aid in creating these two different paths, you can use the `linkResolver` and `hrefResolver` helper functions, defined within `prismic-configuration.js`.
 

--- a/pages/guides/upgrade-to-zero-configuration.mdx
+++ b/pages/guides/upgrade-to-zero-configuration.mdx
@@ -42,7 +42,7 @@ Using [the Next.js example project from the ZEIT Now repository](https://github.
 
 With zero configuration, the `now.json` file is no longer required. You only have to remove the `now.json` file from your project.
 
-For Next.js projects that have a **JavaScript API**, you can use a `/pages/api/` folder, this will allow Next.js to [handle the building of these files for you](https://nextjs.org/docs#api-routes).
+For Next.js projects that have a **JavaScript API**, you can use a `/pages/api/` folder, this will allow Next.js to [handle the building of these files for you](https://nextjs.org/docs/api-routes/introduction).
 
 If your Next.js project is using a different language for the API, put it in the top-level `/api` directory instead. By doing that, you will take advantage of ZEIT Now's native support for Serverless Functions written in multiple languages, while `/pages/api` only supports JavaScript (powered by Next.js).
 


### PR DESCRIPTION
The links still work because the new docs redirect to the new page based on the hash, but that's a client side redirect. with this PR the new paths will be used instead.