### PR TITLE
Variablize email

### DIFF
--- a/components/git-mdx/github/permissions.mdx
+++ b/components/git-mdx/github/permissions.mdx
@@ -1,5 +1,5 @@
 import Note from '~/components/text/note'
-import Link from '~/components/text/link'
+import EmailLink from '~/components/text/email-link'
 import OrgName from '~/components/name/org-name'
 import ProductShortName from '~/components/name/product-short-name'
 
@@ -40,6 +40,5 @@ User permissions allow us to offer an enhanced experience through information ab
 <Note>
   We use the permissions above in order to provide you with the best possible
   deployment experience. If you have any questions or concerns about any of the
-  permission scopes, please reach out to
-  <Link href="mailto:support@zeit.co">support@zeit.co</Link>.
+  permission scopes, please reach out to <EmailLink type="support" />.
 </Note>

--- a/components/references-mdx/api/v1/errors/domains.mdx
+++ b/components/references-mdx/api/v1/errors/domains.mdx
@@ -1,5 +1,6 @@
 import Example from '~/components/example'
 import { Code } from '~/components/text/code'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   editUrl: 'pages/docs/api/v1/api-docs-mdx/errors/domains.mdx',
@@ -171,7 +172,7 @@ The domain name can't be created. Most probably it couldn't be verified.
 
 ### Failed to Add Domain after Purchase
 
-We were able to purchase a domain for you but we had an error when trying to add it to your account. Please contact us on [zeit.chat](/chat) or via [support@zeit.com](mailto:support@zeit.co).
+We were able to purchase a domain for you but we had an error when trying to add it to your account. Please contact us on [zeit.chat](/chat) or via <EmailLink type="support" />.
 
 <Example>
   <Code lang="json">{`{

--- a/components/references-mdx/api/v2/endpoints/domains.mdx
+++ b/components/references-mdx/api/v2/endpoints/domains.mdx
@@ -81,7 +81,7 @@ The response of this API can be controlled with the following optional query par
       "creator": {
         "id": "ZspSRT4ljIEEmMHgoDwKWDei",
         "username": "zeit_user",
-        "email": "demo@zeit.co"
+        "email": "demo@example.com"
       }
     }
   ],
@@ -176,7 +176,7 @@ been created, the user may retry the same POST and the endpoint shall return
     "creator": {
       "id": "ZspSRT4ljIEEmMHgoDwKWDei",
       "username": "zeit_user",
-      "email": "demo@zeit.co"
+      "email": "demo@example.com"
     }
   }
 }`}</Code>
@@ -263,7 +263,7 @@ Initiate a domain transfer request from an external Registrar to <OrgName />.
     "creator": {
       "id": "ZspSRT4ljIEEmMHgoDwKWDei",
       "username": "zeit_user",
-      "email": "demo@zeit.co"
+      "email": "demo@example.com"
     }
   }
 }`}</Code>
@@ -336,7 +336,7 @@ Verify a domain after adding either the intended nameservers or DNS TXT verifica
     "creator": {
       "id": "ZspSRT4ljIEEmMHgoDwKWDei",
       "username": "zeit_user",
-      "email": "demo@zeit.co"
+      "email": "demo@example.com"
     }
   }
 }`}</Code>
@@ -429,7 +429,7 @@ Get information for a single domain in an account or team.
     "creator": {
       "id": "ZspSRT4ljIEEmMHgoDwKWDei",
       "username": "zeit_user",
-      "email": "demo@zeit.co"
+      "email": "demo@example.com"
     },
     "suffix": false,
     "aliases": [],

--- a/components/references-mdx/api/v2/errors/domains.mdx
+++ b/components/references-mdx/api/v2/errors/domains.mdx
@@ -1,4 +1,5 @@
 import { Code } from '~/components/text/code'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   editUrl: 'pages/docs/api/v2/api-docs-mdx/errors/domains.mdx',
@@ -148,7 +149,7 @@ The domain name can't be created. Most probably it couldn't be verified.
 
 ### Failed to Add Domain after Purchase
 
-We were able to purchase a domain for you but we had an error when trying to add it to your account. Please contact us on [zeit.chat](/chat) or via [support@zeit.com](mailto:support@zeit.co).
+We were able to purchase a domain for you but we had an error when trying to add it to your account. Please contact us on [zeit.chat](/chat) or via <EmailLink type="support" />.
 
 <Code lang="json">{`{
   "error": {

--- a/components/text/email-link.js
+++ b/components/text/email-link.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '~/components/text/link'
 
 const typeToEmail = {
   abuse: 'abuse@zeit.co',
@@ -6,13 +7,13 @@ const typeToEmail = {
 }
 
 const EmailLink = ({ children, type, subject }) => (
-  <a
-    href={`mailto:${typeToEmail(type)}${
+  <Link
+    href={`mailto:${typeToEmail[type]}${
       subject ? `?subject=${encodeURIComponent(subject)}` : ''
     }`}
   >
     {children || type}
-  </a>
+  </Link>
 )
 
 export default EmailLink

--- a/components/text/email-link.js
+++ b/components/text/email-link.js
@@ -2,8 +2,8 @@ import React from 'react'
 import Link from '~/components/text/link'
 
 const typeToEmail = {
-  abuse: 'abuse@zeit.co',
-  support: 'support@zeit.co'
+  support: 'support@zeit.co',
+  enterprise: 'enterprise@zeit.co'
 }
 
 const EmailLink = ({ children, type, subject }) => (
@@ -12,7 +12,7 @@ const EmailLink = ({ children, type, subject }) => (
       subject ? `?subject=${encodeURIComponent(subject)}` : ''
     }`}
   >
-    {children || type}
+    {children || typeToEmail[type]}
   </Link>
 )
 

--- a/components/text/email-link.js
+++ b/components/text/email-link.js
@@ -1,0 +1,18 @@
+import React from 'react'
+
+const typeToEmail = {
+  abuse: 'abuse@zeit.co',
+  support: 'support@zeit.co'
+}
+
+const EmailLink = ({ children, type, subject }) => (
+  <a
+    href={`mailto:${typeToEmail(type)}${
+      subject ? `?subject=${encodeURIComponent(subject)}` : ''
+    }`}
+  >
+    {children || type}
+  </a>
+)
+
+export default EmailLink

--- a/components/text/email-link.js
+++ b/components/text/email-link.js
@@ -3,7 +3,7 @@ import Link from '~/components/text/link'
 
 const typeToEmail = {
   support: 'support@zeit.co',
-  enterprise: 'enterprise@zeit.co'
+  sales: 'sales@zeit.co'
 }
 
 const EmailLink = ({ children, type, subject }) => (

--- a/lib/data/guides.json
+++ b/lib/data/guides.json
@@ -263,7 +263,7 @@
     "authors": ["msweeneydev"],
     "url": "/guides/transferring-domains-to-zeit-now",
     "editUrl": "pages/guides/transferring-domains-to-zeit-now.mdx",
-    "lastEdited": "2020-04-14T00:02:08.000Z"
+    "lastEdited": "2020-04-15T01:44:57.000Z"
   },
   {
     "title": "Create an Ember App and Deploy It with ZEIT Now",

--- a/pages/docs/directory-listing.mdx
+++ b/pages/docs/directory-listing.mdx
@@ -1,12 +1,13 @@
 import Standard from '~/components/layout/standard'
 import Link from '~/components/text/link'
 import OrgName from '~/components/name/org-name'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Directory Listing',
   description: 'what is the Directory Listing page and what does it do?',
   editUrl: 'pages/docs/directory-listing.mdx',
-  lastEdited: '2020-04-13T23:47:53.000Z'
+  lastEdited: '2020-04-15T00:52:04.000Z'
 }
 
 The Directory Listing page, which shows the contents within a directory, is served when a particular path is both a directory and does not have an index file within it.
@@ -24,7 +25,7 @@ Using advanced configuration, you can also implement [a custom 404 page](/docs/c
 ### Troubleshoot
 
 - If you are seeing this page as a result of problems setting up your project, please [see our build step documentation](/docs/v2/build-step).
-- If you have tried everything above, please either leave feedback below or [contact support](mailto:support@zeit.co) with more information about your problem.
+- If you have tried everything above, please either leave feedback below or <EmailLink type="support">contact support</EmailLink> with more information about your problem.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/application/DEPLOYMENT_BLOCKED.mdx
+++ b/pages/docs/error/application/DEPLOYMENT_BLOCKED.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Deployment Blocked',
@@ -24,7 +25,7 @@ The deployment was blocked by the platform infrastructure layer due to a problem
 #### Troubleshoot
 
 - If you have recently downgraded to the Hobby plan, you will need to redeploy your projects to make them available once again.
-- **[Contact Support](mailto:support@zeit.co)** to see why your deployment was blocked and how to resolve it.
+- **<EmailLink type="support">Contact Support</EmailLink>** to see why your deployment was blocked and how to resolve it.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/application/DEPLOYMENT_BLOCKED.mdx
+++ b/pages/docs/error/application/DEPLOYMENT_BLOCKED.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Deployment Blocked',
   description: 'The requested deployment was blocked.',
   editUrl: 'pages/docs/error/application/DEPLOYMENT_BLOCKED.mdx',
-  lastEdited: '2020-03-19T20:16:39.000Z'
+  lastEdited: '2020-04-15T00:48:49.000Z'
 }
 
 #### Application Error

--- a/pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx
+++ b/pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx
@@ -8,7 +8,7 @@ export const meta = {
   description:
     'The application received too many requests and was rate limited.',
   editUrl: 'pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx',
-  lastEdited: '2019-10-07T13:32:43.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Application Error

--- a/pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx
+++ b/pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Internal Function Rate Limit',
@@ -9,7 +10,6 @@ export const meta = {
   editUrl: 'pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx',
   lastEdited: '2019-10-07T13:32:43.000Z'
 }
-
 #### Application Error
 
 An error occurred because requests were being made too quickly and were subsuquently rate limited by our upstream provider.
@@ -27,7 +27,7 @@ An error occurred because requests were being made too quickly and were subsuque
 #### Troubleshoot
 
 - Try again in a few seconds.
-- If waiting does not solve this issue, **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- If waiting does not solve this issue, **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx
+++ b/pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Internal Function Rate Limit',
@@ -10,6 +10,7 @@ export const meta = {
   editUrl: 'pages/docs/error/application/INTERNAL_FUNCTION_RATE_LIMIT.mdx',
   lastEdited: '2019-10-07T13:32:43.000Z'
 }
+
 #### Application Error
 
 An error occurred because requests were being made too quickly and were subsuquently rate limited by our upstream provider.

--- a/pages/docs/error/application/RESOURCE_NOT_FOUND.mdx
+++ b/pages/docs/error/application/RESOURCE_NOT_FOUND.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Resource Not Found',
   description: 'The requested file or Serverless Function was not found.',
   editUrl: 'pages/docs/error/application/RESOURCE_NOT_FOUND.mdx',
-  lastEdited: '2019-10-07T13:34:36.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Application Error

--- a/pages/docs/error/application/RESOURCE_NOT_FOUND.mdx
+++ b/pages/docs/error/application/RESOURCE_NOT_FOUND.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Resource Not Found',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/application/RESOURCE_NOT_FOUND.mdx',
   lastEdited: '2019-10-07T13:34:36.000Z'
 }
+
 #### Application Error
 
 The requested file or Serverless Function was not found in the application.

--- a/pages/docs/error/application/RESOURCE_NOT_FOUND.mdx
+++ b/pages/docs/error/application/RESOURCE_NOT_FOUND.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Resource Not Found',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/application/RESOURCE_NOT_FOUND.mdx',
   lastEdited: '2019-10-07T13:34:36.000Z'
 }
-
 #### Application Error
 
 The requested file or Serverless Function was not found in the application.
@@ -27,7 +27,7 @@ The requested file or Serverless Function was not found in the application.
 
 - Make sure the link you accessed is correct.
 - Check the output of your deployment.
-- If you believe the link is correct and you were not expecting this error; **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- If you believe the link is correct and you were not expecting this error; **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx
+++ b/pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Too Many Filesystem Checks',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx',
   lastEdited: '2020-01-13T13:41:14.000Z'
 }
+
 #### Application Error
 
 An error occurred in the application when matching too many rewrites.

--- a/pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx
+++ b/pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Too Many Filesystem Checks',
   description: 'The filesystem was checked too many times during routing.',
   editUrl: 'pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx',
-  lastEdited: '2020-01-13T13:41:14.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Application Error

--- a/pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx
+++ b/pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Too Many Filesystem Checks',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/application/TOO_MANY_FILESYSTEM_CHECKS.mdx',
   lastEdited: '2020-01-13T13:41:14.000Z'
 }
-
 #### Application Error
 
 An error occurred in the application when matching too many rewrites.
@@ -25,7 +25,7 @@ An error occurred in the application when matching too many rewrites.
 #### Troubleshoot
 
 - Reduce the number of rewrites that match the erroring request path.
-- **[Contact Support](mailto:support@zeit.co)** if you have trouble locating the rewrites causing the error.
+- **<EmailLink type="support">Contact Support</EmailLink>** if you have trouble locating the rewrites causing the error.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx
+++ b/pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Deployment Not Found',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx',
   lastEdited: '2019-10-21T11:26:47.000Z'
 }
-
 #### Platform Error
 
 The deployment was not found in the platform infrastructure layer.
@@ -27,7 +27,7 @@ The deployment was not found in the platform infrastructure layer.
 
 - Make sure the link you accessed is correct.
 - If you were expecting a deployment to be assigned to a domain that you are accessing, please ensure that the domain is [assigned to a project](/docs/v2/custom-domains/#adding-a-domain) and there is a [production deployment](/docs/v2/custom-domains/#deploying-with-your-domain).
-- If the link is correct and you were not expecting this error; **[Contact Support](mailto:support@zeit.co)**.
+- If the link is correct and you were not expecting this error; **<EmailLink type="support">Contact Support</EmailLink>**.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx
+++ b/pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Deployment Not Found',
   description: 'The requested deployment was not found.',
   editUrl: 'pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx',
-  lastEdited: '2019-10-21T11:26:47.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx
+++ b/pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Deployment Not Found',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/DEPLOYMENT_NOT_FOUND.mdx',
   lastEdited: '2019-10-21T11:26:47.000Z'
 }
+
 #### Platform Error
 
 The deployment was not found in the platform infrastructure layer.

--- a/pages/docs/error/platform/DEPLOYMENT_NOT_READY_REDIRECTING.mdx
+++ b/pages/docs/error/platform/DEPLOYMENT_NOT_READY_REDIRECTING.mdx
@@ -3,12 +3,13 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Deployment Not Ready',
   description: 'The requested deployment is not ready and will be redirected.',
   editUrl: 'pages/docs/error/platform/DEPLOYMENT_NOT_READY_REDIRECTING.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T00:52:04.000Z'
 }
 
 #### Platform Error
@@ -28,7 +29,7 @@ The deployment has not made it through the deployment pipeline and the request w
 #### Troubleshoot
 
 - Please wait for a few seconds and refresh.
-- If the error does not resolve when refreshing, please **[contact support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- If the error does not resolve when refreshing, please **<EmailLink type="support">contact support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Failed To Get Deployment',
@@ -10,6 +10,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Failed To Get Deployment',
@@ -9,7 +10,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -26,7 +26,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx
@@ -8,7 +8,7 @@ export const meta = {
   description:
     'The platform infrastructure failed to fetch the requested deployment.',
   editUrl: 'pages/docs/error/platform/INTERNAL_DEPLOYMENT_FETCH_FAILED.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Failed to Invoke Serverless Function',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx',
-  lastEdited: '2019-09-26T14:00:22.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Failed to Invoke Serverless Function',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Failed to Invoke Serverless Function',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_FUNCTION_INVOCATION_FAILED.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx
+++ b/pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Serverless Function not found.',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
+
 #### Platform Error
 
 The requested Serverless Function was not found by the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx
+++ b/pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Serverless Function not found.',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
-
 #### Platform Error
 
 The requested Serverless Function was not found by the platform infrastructure layer.
@@ -26,7 +26,7 @@ The requested Serverless Function was not found by the platform infrastructure l
 #### Troubleshoot
 
 - Make sure the link you accessed is correct.
-- If you believe the link is correct and you were not expecting this error; **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- If you believe the link is correct and you were not expecting this error; **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx
+++ b/pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Serverless Function not found.',
   description: 'The requested Serverless Function was not found.',
   editUrl: 'pages/docs/error/platform/INTERNAL_FUNCTION_NOT_FOUND.mdx',
-  lastEdited: '2019-09-26T14:00:22.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Resolving Host Failed',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Resolving Host Failed',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Resolving Host Failed',
   description: 'The platform infrastructure failed to resolve the hostname.',
   editUrl: 'pages/docs/error/platform/INTERNAL_HOSTNAME_RESOLVE_FAILED.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx
+++ b/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Invalid Serverless Function Accounts',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx
+++ b/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Invalid Serverless Function Accounts',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx
+++ b/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Invalid Serverless Function Accounts',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_ACCOUNTS.mdx',
-  lastEdited: '2019-09-26T14:00:22.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx
+++ b/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Invalid Serverless Function Region',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx
+++ b/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Invalid Serverless Function Region',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx',
   lastEdited: '2019-09-26T14:00:22.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx
+++ b/pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Invalid Serverless Function Region',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_INVALID_FUNCTION_REGION.mdx',
-  lastEdited: '2019-09-26T14:00:22.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx
+++ b/pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx
@@ -3,6 +3,7 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Missing Response From Cache',
@@ -10,7 +11,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -27,7 +27,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx
+++ b/pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx
@@ -9,7 +9,7 @@ export const meta = {
   title: 'Missing Response From Cache',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx
+++ b/pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx
@@ -3,7 +3,7 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Missing Response From Cache',
@@ -11,6 +11,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_MISSING_RESPONSE_FROM_CACHE.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx
@@ -9,7 +9,7 @@ export const meta = {
   title: 'Failed to Resolve Host',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx
@@ -3,7 +3,7 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Failed to Resolve Host',
@@ -11,6 +11,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx
@@ -3,6 +3,7 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Failed to Resolve Host',
@@ -10,7 +11,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_RESOLVE_HOST_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -27,7 +27,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Internal Rewrite Resolve Host Failed',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Internal Rewrite Resolve Host Failed',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Internal Rewrite Resolve Host Failed',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_REWRITE_RESOLVE_HOST_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Static Request Failed',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'Static Request Failed',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Static Request Failed',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_STATIC_REQUEST_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx
@@ -3,6 +3,7 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Serverless Function Unarchive Failed',
@@ -10,7 +11,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.
@@ -27,7 +27,7 @@ An error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx
@@ -9,7 +9,7 @@ export const meta = {
   title: 'Serverless Function Unarchive Failed',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx
+++ b/pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx
@@ -3,7 +3,7 @@ import Snippet from '~/components/snippet'
 import Caption from '~/components/text/caption'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Serverless Function Unarchive Failed',
@@ -11,6 +11,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_UNARCHIVE_FAILED.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx
+++ b/pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx
@@ -1,6 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'An Unexpected Error Occurred',
@@ -8,7 +9,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
-
 #### Platform Error
 
 An unexpected error occurred in the platform infrastructure layer.
@@ -25,7 +25,7 @@ An unexpected error occurred in the platform infrastructure layer.
 
 #### Troubleshoot
 
-- Please **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- Please **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx
+++ b/pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx
@@ -7,7 +7,7 @@ export const meta = {
   title: 'An Unexpected Error Occurred',
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx',
-  lastEdited: '2019-09-23T15:41:06.000Z'
+  lastEdited: '2020-04-15T01:59:48.000Z'
 }
 
 #### Platform Error

--- a/pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx
+++ b/pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx
@@ -1,7 +1,7 @@
 import Standard from '~/components/layout/standard'
 import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'An Unexpected Error Occurred',
@@ -9,6 +9,7 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/INTERNAL_UNEXPECTED_ERROR.mdx',
   lastEdited: '2019-09-23T15:41:06.000Z'
 }
+
 #### Platform Error
 
 An unexpected error occurred in the platform infrastructure layer.

--- a/pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx
@@ -4,6 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Gateway Timeout`,
@@ -11,7 +12,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx',
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
-
 <br />
 
 <Note type="warning">
@@ -38,7 +38,7 @@ An error occurred in the <ProductV1Name /> platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx
@@ -10,9 +10,9 @@ export const meta = {
   title: `${PRODUCT_V1_NAME} Gateway Timeout`,
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T02:03:00.000Z'
 }
-<br />
+
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_GATEWAY_TIMEOUT.mdx
@@ -4,7 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Gateway Timeout`,
@@ -13,7 +13,6 @@ export const meta = {
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
 <br />
-
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx
@@ -4,7 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Create Lock Failed`,
@@ -13,7 +13,6 @@ export const meta = {
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
 <br />
-
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx
@@ -4,6 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Create Lock Failed`,
@@ -11,7 +12,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx',
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
-
 <br />
 
 <Note type="warning">
@@ -38,7 +38,7 @@ An error occurred in the <ProductV1Name /> platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx
@@ -10,9 +10,9 @@ export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Create Lock Failed`,
   description: 'Internal Gateway Timeout',
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_SLOTS_CREATE_LOCK_FAILED.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T02:03:00.000Z'
 }
-<br />
+
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx
@@ -4,6 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Slots Notify Sub Failed`,
@@ -11,7 +12,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx',
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
-
 <br />
 
 <Note type="warning">
@@ -38,7 +38,7 @@ An error occurred in the <ProductV1Name /> platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx
@@ -4,7 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Slots Notify Sub Failed`,
@@ -13,7 +13,6 @@ export const meta = {
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
 <br />
-
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx
@@ -10,9 +10,9 @@ export const meta = {
   title: `${PRODUCT_V1_NAME} Slots Notify Sub Failed`,
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_SLOTS_NOTIFY_SUB_FAILED.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T02:03:00.000Z'
 }
-<br />
+
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx
@@ -10,9 +10,9 @@ export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Query IP Failed`,
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T02:03:00.000Z'
 }
-<br />
+
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx
@@ -4,6 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Query IP Failed`,
@@ -11,7 +12,6 @@ export const meta = {
   editUrl: 'pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx',
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
-
 <br />
 
 <Note type="warning">
@@ -38,7 +38,7 @@ An error occurred in the <ProductV1Name /> platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_QUERY_IP_FAILED.mdx
@@ -4,7 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Query IP Failed`,
@@ -13,7 +13,6 @@ export const meta = {
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
 <br />
-
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx
@@ -11,9 +11,9 @@ export const meta = {
   description: 'An error occurred in the platform infrastructure layer.',
   editUrl:
     'pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T02:03:00.000Z'
 }
-<br />
+
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx
@@ -4,6 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
+mport EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Unknown Status Code`,
@@ -12,7 +13,6 @@ export const meta = {
     'pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx',
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
-
 <br />
 
 <Note type="warning">
@@ -39,7 +39,7 @@ An error occurred in the <ProductV1Name /> platform infrastructure layer.
 
 #### Troubleshoot
 
-- **[Contact Support](mailto:support@zeit.co)** along with the ID on the error page from your deployment.
+- **<EmailLink type="support">Contact Support</EmailLink>** along with the ID on the error page from your deployment.
 
 export default ({ children }) => <Standard meta={meta}>{children}</Standard>
 

--- a/pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx
+++ b/pages/docs/error/platform/V1_INTERNAL_SLOTS_UNKNOWN_STATUS_CODE.mdx
@@ -4,7 +4,7 @@ import Note from '~/components/text/note'
 import { InlineCode } from '~/components/text/code'
 import ProductV1Name from '~/components/name/product-v1-name'
 import { PRODUCT_V1_NAME } from '~/lib/constants'
-mport EmailLink from '~/components/text/email-link'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `${PRODUCT_V1_NAME} Internal Slots Unknown Status Code`,
@@ -14,7 +14,6 @@ export const meta = {
   lastEdited: '2020-04-14T00:02:08.000Z'
 }
 <br />
-
 <Note type="warning">
   This error is from <ProductV1Name />.{' '}
   <Link href="https://zeit.co/guides/migrate-to-zeit-now">

--- a/pages/docs/v1/features/scaling.mdx
+++ b/pages/docs/v1/features/scaling.mdx
@@ -6,13 +6,14 @@ import ProductV1Name from '~/components/name/product-v1-name'
 import CliV1Name from '~/components/name/cli-v1-name'
 import { PRODUCT_SHORT_V1_NAME } from '~/lib/constants'
 import Note from '~/components/text/note'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Global Scaling',
   description: `Scaling your deployments to be instances in multiple global locations with ${PRODUCT_SHORT_V1_NAME}`,
   date: '01 Apr 2018',
   editUrl: 'pages/docs/v1/features/scaling.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T00:52:04.000Z'
 }
 
 In this feature guide, you will learn how to globally distribute
@@ -99,7 +100,7 @@ created if the following statements are true:
 
 Within each [data center](#datacenter), your deployment can consist
 of up to 10 instances. If you want to increase this limit,
-you can [contact us](mailto:support@zeit.co) for a special offer.
+you can <EmailLink type="support">contact us</EmailLink> for a special offer.
 
 ## Scaling While Deploying
 

--- a/pages/docs/v1/other/faq.mdx
+++ b/pages/docs/v1/other/faq.mdx
@@ -12,7 +12,7 @@ export const meta = {
   description: `The answers to our most frequently asked questions for ${PRODUCT_SHORT_V1_NAME} and other ${ORG_NAME} products and services`,
   date: '30 Jan 2018',
   editUrl: 'pages/docs/v1/other/faq.mdx',
-  lastEdited: '2020-04-15T01:55:35.000Z'
+  lastEdited: '2020-04-15T04:12:15.000Z'
 }
 
 ## Where can I see the current status of the platform?
@@ -86,7 +86,7 @@ The storage limit of any plan is shown under the plan on [the pricing page](/pri
 
 At the moment there is no way to change this. We do have this on the roadmap though!
 
-For <EmailLink type="enterprise" subject="Custom Hardware Resources">enterprise customers</EmailLink>, we offer customizations which include more resources for deployments.
+For <EmailLink type="sales" subject="Custom Hardware Resources">enterprise customers</EmailLink>, we offer customizations which include more resources for deployments.
 
 ## How do I update my deployment's files or code?
 
@@ -266,7 +266,7 @@ If you do not want to renew a domain purchased with <ProductShortV1Name /> Domai
 
 ## Do you offer custom support or help with Next.js?
 
-Yes, we do. Let us know if you'd like our help at <EmailLink type="enterprise" subject="Next.js Custom Support" />.
+Yes, we do. Let us know if you'd like our help at <EmailLink type="sales" subject="Next.js Custom Support" />.
 
 ## Is it possible to remove deployment logs?
 
@@ -314,13 +314,13 @@ We recommend that you only do this for temporary files and use [now-storage](htt
 
 Both our DNS and HTTP(s) load balancing services have sophisticated DDoS protections in place.
 
-Attacks come in very different forms and sizes. Therefore, we offer more advanced protection in the <EmailLink type="enterprise" subject="Advanced DDoS Protection">enterprise</EmailLink> tiers.
+Attacks come in very different forms and sizes. Therefore, we offer more advanced protection in the <EmailLink type="sales" subject="Advanced DDoS Protection">enterprise</EmailLink> tiers.
 
 ## How do I set up a password for my <NameWrapper name={ORG_NAME} /> Account?
 
 ​<OrgV1Name />'s login is serverless. You just need your email address and don't need to remember yet another password.
 
-For custom requirements, you can contact us at <EmailLink type="enterprise" subject="Advanced Authentication" />.
+For custom requirements, you can contact us at <EmailLink type="sales" subject="Advanced Authentication" />.
 
 ## Does <NameWrapper name={PRODUCT_SHORT_V1_NAME} /> offer support for IPv6?
 

--- a/pages/docs/v1/other/faq.mdx
+++ b/pages/docs/v1/other/faq.mdx
@@ -12,7 +12,7 @@ export const meta = {
   description: `The answers to our most frequently asked questions for ${PRODUCT_SHORT_V1_NAME} and other ${ORG_NAME} products and services`,
   date: '30 Jan 2018',
   editUrl: 'pages/docs/v1/other/faq.mdx',
-  lastEdited: '2020-04-15T01:46:42.000Z'
+  lastEdited: '2020-04-15T01:55:35.000Z'
 }
 
 ## Where can I see the current status of the platform?
@@ -115,7 +115,7 @@ We are working on a domain transfer tool to make this process easier.
 
 For now, it is not possible to transfer a domain into <OrgV1Name /> Domains, but you can [change your domain nameservers to point to zeit.world](https://zeit.co/world) to use <ProductShortV1Name /> as a DNS.
 
-If you need to transfer your domain out of <OrgV1Name /> Domains, you can contact us at [support@zeit.co](mailto:support@zeit.co?subject=Domain%20Transfer) with the domain you would like to transfer.
+If you need to transfer your domain out of <OrgV1Name /> Domains, you can contact us at <EmailLink type="support" subject="Domain Transfer" /> with the domain you would like to transfer.
 
 If you would like to move a domain from one <OrgV1Name /> account to another, you could do so by running the following commands:
 
@@ -166,7 +166,7 @@ This will ensure the bot is no longer running before you remove it or deploy a n
 
 ## How do I Change the nameservers of a domain purchased with <NameWrapper name={ORG_NAME} /> Domains?
 
-This is not currently possible to do via the [<CliV1Name />](/docs/clients/now-cli), but you can contact us at [support@zeit.co](mailto:support@zeit.co?subject=Change%20Purchased%20Domain%20Nameserver) with your desired nameservers and, after a security verification of the ownership, we can change them for you.
+This is not currently possible to do via the [<CliV1Name />](/docs/clients/now-cli), but you can contact us at <EmailLink type="support" subject="Change Purchased Domain Nameserver" /> with your desired nameservers and, after a security verification of the ownership, we can change them for you.
 
 ## How can I avoid the prompt about the deployment being public under the OSS Plan?
 
@@ -180,7 +180,7 @@ Check ["Why does my deployment occasionally have long response times?"](/docs/ot
 
 ## If I need a special invoice, how do I get it?
 
-We send a receipt to your email address for every card transaction including a link to download the invoice as a PDF. Your invoice can also be downloaded from the [Usage section of your dashboard](https://zeit.co/dashboard/usage). For special invoicing requests, please contact us at [support@zeit.co](support@zeit.co?subject=Invoice) with the following information:
+We send a receipt to your email address for every card transaction including a link to download the invoice as a PDF. Your invoice can also be downloaded from the [Usage section of your dashboard](https://zeit.co/dashboard/usage). For special invoicing requests, please contact us at <EmailLink type="support" subject="Invoice" /> with the following information:
 
 - Company name
 - Billing address
@@ -274,7 +274,7 @@ This is not currently possible.
 
 ## Is it possible to download the files or code of my deployments?
 
-It is not possible to download files of a deployment from the CLI nor the web. Contact us at [support@zeit.co](support@zeit.co?subject=Download%20Deployment%20Code) from the personal account's email address or, in the event the request pertains to a team, the team owner's email address, and we can help you.
+It is not possible to download files of a deployment from the CLI nor the web. Contact us at &lt;EmailLink type="support" subject="Download Deployment Code /> from the personal account's email address or, in the event the request pertains to a team, the team owner's email address, and we can help you.
 
 ## How do I run scheduled tasks on the <NameWrapper name={PRODUCT_SHORT_V1_NAME} /> platform?
 

--- a/pages/docs/v1/other/faq.mdx
+++ b/pages/docs/v1/other/faq.mdx
@@ -5,13 +5,14 @@ import OrgV1Name from '~/components/name/org-v1-name'
 import NameWrapper from '~/components/name/name-wrapper'
 import { PRODUCT_SHORT_V1_NAME, ORG_NAME } from '~/lib/constants'
 import CliV1Name from '~/components/name/cli-v1-name'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Frequently Asked Questions',
   description: `The answers to our most frequently asked questions for ${PRODUCT_SHORT_V1_NAME} and other ${ORG_NAME} products and services`,
   date: '30 Jan 2018',
   editUrl: 'pages/docs/v1/other/faq.mdx',
-  lastEdited: '2020-04-14T15:19:32.000Z'
+  lastEdited: '2020-04-15T01:46:42.000Z'
 }
 
 ## Where can I see the current status of the platform?
@@ -85,7 +86,7 @@ The storage limit of any plan is shown under the plan on [the pricing page](/pri
 
 At the moment there is no way to change this. We do have this on the roadmap though!
 
-For [enterprise customers](mailto:enterprise@zeit.co?subject=Custom%20Hardware%20Resources), we offer customizations which include more resources for deployments.
+For <EmailLink type="enterprise" subject="Custom Hardware Resources">enterprise customers</EmailLink>, we offer customizations which include more resources for deployments.
 
 ## How do I update my deployment's files or code?
 
@@ -265,7 +266,7 @@ If you do not want to renew a domain purchased with <ProductShortV1Name /> Domai
 
 ## Do you offer custom support or help with Next.js?
 
-Yes, we do. Let us know if you'd like our help at [enterprise@zeit.co](enterprise@zeit.co?subject=Next.js%20Custom%20Support).
+Yes, we do. Let us know if you'd like our help at <EmailLink type="enterprise" subject="Next.js Custom Support" />.
 
 ## Is it possible to remove deployment logs?
 
@@ -313,13 +314,13 @@ We recommend that you only do this for temporary files and use [now-storage](htt
 
 Both our DNS and HTTP(s) load balancing services have sophisticated DDoS protections in place.
 
-Attacks come in very different forms and sizes. Therefore, we offer more advanced protection in the [enterprise](mailto:enterprise@zeit.co?subject=Advanced%20DDoS%20Protection) tiers.
+Attacks come in very different forms and sizes. Therefore, we offer more advanced protection in the <EmailLink type="enterprise" subject="Advanced DDoS Protection">enterprise</EmailLink> tiers.
 
 ## How do I set up a password for my <NameWrapper name={ORG_NAME} /> Account?
 
 ​<OrgV1Name />'s login is serverless. You just need your email address and don't need to remember yet another password.
 
-For custom requirements, you can contact us at [enterprise@zeit.co](mailto:enterprise@zeit.co?subject=Advanced%20Authentication).
+For custom requirements, you can contact us at <EmailLink type="enterprise" subject="Advanced Authentication" />.
 
 ## Does <NameWrapper name={PRODUCT_SHORT_V1_NAME} /> offer support for IPv6?
 

--- a/pages/docs/v1/other/restrictions.mdx
+++ b/pages/docs/v1/other/restrictions.mdx
@@ -8,7 +8,7 @@ export const meta = {
   description: `A guide to what restrictions you have when deploying to ${PRODUCT_SHORT_V1_NAME}`,
   date: '20 Mar 2018',
   editUrl: 'pages/docs/v1/other/restrictions.mdx',
-  lastEdited: '2020-04-15T00:52:04.000Z'
+  lastEdited: '2020-04-15T00:54:08.000Z'
 }
 
 The purpose of this page is to guide you through
@@ -60,7 +60,7 @@ charged.
 In addition to that, it would also be beneficial
 to ensure that emails from our platform
 don't end up in your spam folder or get filtered out
-as junk (they're being sent by an address ending with `@zeit.co`).
+as junk.
 
 ### Deployed under a Higher Plan
 

--- a/pages/docs/v1/other/restrictions.mdx
+++ b/pages/docs/v1/other/restrictions.mdx
@@ -1,13 +1,14 @@
 import Doc from '~/components/layout/docs'
 import { PRODUCT_SHORT_V1_NAME } from '~/lib/constants'
 import ProductShortV1Name from '~/components/name/product-short-v1-name'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Restrictions',
   description: `A guide to what restrictions you have when deploying to ${PRODUCT_SHORT_V1_NAME}`,
   date: '20 Mar 2018',
   editUrl: 'pages/docs/v1/other/restrictions.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T00:52:04.000Z'
 }
 
 The purpose of this page is to guide you through
@@ -98,6 +99,6 @@ failed payments, the following will apply as well:
 
 If you need additional advice on how to unblock your
 deployments or prevent them from initially getting
-blocked, please contact us at [support@zeit.co](mailto:support@zeit.co).
+blocked, please contact us at <EmailLink type="support" />.
 
 export default ({ children }) => <Doc meta={meta}>{children}</Doc>

--- a/pages/docs/v1/other/support-channels.mdx
+++ b/pages/docs/v1/other/support-channels.mdx
@@ -1,13 +1,14 @@
 import Doc from '~/components/layout/docs'
 import OrgV1Name from '~/components/name/org-v1-name'
 import { ORG_NAME, PRODUCT_SHORT_V1_NAME } from '~/lib/constants'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Support Channels',
   description: `Finding help beyond documentation for ${ORG_NAME} and ${PRODUCT_SHORT_V1_NAME}`,
   date: '21 Jul 2017',
   editUrl: 'pages/docs/v1/other/support-channels.mdx',
-  lastEdited: '2020-04-14T15:19:32.000Z'
+  lastEdited: '2020-04-15T00:52:04.000Z'
 }
 
 We have a few support channels you can use to clarify doubts and solve issues.
@@ -38,6 +39,6 @@ You can use Twitter to send a DM to, or mention [@zeithq](https://twitter.com/ze
 
 ## Email
 
-Last but not least, you can reach out to us by email at [support@zeit.co](mailto:support@zeit.co). If you have very in-depth questions or queries related to private information (eg. billing issues) that you don't want to share in our other support channels, or you would just prefer to use email you can contact us and we will happily help you.
+Last but not least, you can reach out to us by email at <EmailLink type="support" />. If you have very in-depth questions or queries related to private information (eg. billing issues) that you don't want to share in our other support channels, or you would just prefer to use email you can contact us and we will happily help you.
 
 export default ({ children }) => <Doc meta={meta}>{children}</Doc>

--- a/pages/docs/v2/platform/limits.mdx
+++ b/pages/docs/v2/platform/limits.mdx
@@ -3,12 +3,13 @@ import Limits from '~/components/limits'
 import Note from '~/components/text/note'
 import ProductName from '~/components/name/product-name'
 import { PRODUCT_NAME } from '~/lib/constants'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: 'Limits',
   description: `A list of limits and limitations that apply on the ${PRODUCT_NAME} platform.`,
   editUrl: 'pages/docs/v2/platform/limits.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T01:36:00.000Z'
 }
 
 This page outlines all relevant limits and limitations present when using the <ProductName /> platform.
@@ -52,7 +53,7 @@ The total size of [Environment Variables](/docs/v2/build-step#environment-variab
 
 ## Domains
 
-The maximum amount of domains that can be applied to a single project is **50**. If your Project requires more than 50 domains, please [contact our enterprise team](mailto:enterprise@zeit.co).
+The maximum amount of domains that can be applied to a single project is **50**. If your Project requires more than 50 domains, please <EmailLink type="enterprise">contact our enterprise team</EmailLink>.
 
 ## Files
 
@@ -94,7 +95,7 @@ You can use the [functions](/docs/configuration#project/functions) property to a
 
 The maximum number of concurrent executions for a [Serverless Function](/docs/v2/serverless-functions/introduction/) is `1000`.
 
-If you require a limit above `1000`, you should [contact our enterprise department](mailto:sales@zeit.co) to discuss custom limits available on an enterprise plan.
+If you require a limit above `1000`, you should <EmailLink type="enterprise">contact our enterprise team</EmailLink> to discuss custom limits available on an enterprise plan.
 
 ## Serverless Function Payload Size Limit
 

--- a/pages/docs/v2/platform/limits.mdx
+++ b/pages/docs/v2/platform/limits.mdx
@@ -9,7 +9,7 @@ export const meta = {
   title: 'Limits',
   description: `A list of limits and limitations that apply on the ${PRODUCT_NAME} platform.`,
   editUrl: 'pages/docs/v2/platform/limits.mdx',
-  lastEdited: '2020-04-15T01:36:00.000Z'
+  lastEdited: '2020-04-15T04:12:15.000Z'
 }
 
 This page outlines all relevant limits and limitations present when using the <ProductName /> platform.
@@ -53,7 +53,7 @@ The total size of [Environment Variables](/docs/v2/build-step#environment-variab
 
 ## Domains
 
-The maximum amount of domains that can be applied to a single project is **50**. If your Project requires more than 50 domains, please <EmailLink type="enterprise">contact our enterprise team</EmailLink>.
+The maximum amount of domains that can be applied to a single project is **50**. If your Project requires more than 50 domains, please <EmailLink type="sales">contact our enterprise team</EmailLink>.
 
 ## Files
 
@@ -95,7 +95,7 @@ You can use the [functions](/docs/configuration#project/functions) property to a
 
 The maximum number of concurrent executions for a [Serverless Function](/docs/v2/serverless-functions/introduction/) is `1000`.
 
-If you require a limit above `1000`, you should <EmailLink type="enterprise">contact our enterprise team</EmailLink> to discuss custom limits available on an enterprise plan.
+If you require a limit above `1000`, you should <EmailLink type="sales">contact our enterprise team</EmailLink> to discuss custom limits available on an enterprise plan.
 
 ## Serverless Function Payload Size Limit
 

--- a/pages/guides/transferring-domains-to-zeit-now.mdx
+++ b/pages/guides/transferring-domains-to-zeit-now.mdx
@@ -8,6 +8,7 @@ import ProductName from '~/components/name/product-name'
 import { PRODUCT_NAME, ORG_NAME, PRODUCT_SHORT_NAME } from '~/lib/constants'
 import NameWrapper from '~/components/name/name-wrapper'
 import ProductShortName from '~/components/name/product-short-name'
+import EmailLink from '~/components/text/email-link'
 
 export const meta = {
   title: `Transferring Domains to ${PRODUCT_NAME}`,
@@ -16,7 +17,7 @@ export const meta = {
   authors: ['msweeneydev'],
   url: '/guides/transferring-domains-to-zeit-now',
   editUrl: 'pages/guides/transferring-domains-to-zeit-now.mdx',
-  lastEdited: '2020-04-14T00:02:08.000Z'
+  lastEdited: '2020-04-15T01:44:57.000Z'
 }
 
 With <ProductName />, you can [assign a custom domain](/docs/v2/custom-domains#adding-a-domain) to any of your projects. If you want to transfer your domain in from an external registrar to <OrgName />, you can do that painlessly without worrying about domain and DNS configuration.
@@ -104,7 +105,7 @@ For more information on production domains, you can read the [custom domains doc
 
 ## Transferring Out
 
-If you are looking to transfer your domain away from <ProductName />, you can do so by [emailing support](mailto:support@zeit.co?subject=Domain%20Transfer%20Out) at support@zeit.co with details of the domain you wish to transfer.
+If you are looking to transfer your domain away from <ProductName />, you can do so by <EmailLink type="support" subject="Domain Transfer Out">emailing support</EmailLink> with details of the domain you wish to transfer.
 
 <Note type="warning">
   Before requesting a domain transfer, make sure that the domain has been


### PR DESCRIPTION
Adds `EmailLink` component and replace all emails with this component. Also makes minor tweaks (commented).

Uses `sales@` over `enterprise@` per advice from the sales team.